### PR TITLE
fix: Grant write permission to Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary

Changed `pull-requests` permission from `read` to `write` so Claude Code Review can post review comments on PRs.

## Changes

- `.github/workflows/claude-code-review.yml`: `pull-requests: read` → `pull-requests: write`

## Why

The Claude Code Review workflow was running successfully but couldn't post comments because it only had read access to pull requests. This fix enables Claude to actually leave review feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)