### PR TITLE
refactor: restructure CI/CD pipeline for deploy-then-test E2E strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,43 +95,8 @@ jobs:
           E2E_MODE: 'mock'
           NEXT_PUBLIC_MOCK_MODE: 'true'
 
-  # Free Mode E2E Tests - Only run when API key secrets are configured
-  # Tests real API integrations with actual provider keys
-  app-e2e-free:
-    name: App E2E (Free Mode)
-    runs-on: ubuntu-latest
-    # Only run if secrets are available (will be skipped in forks)
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-      - run: npm ci
-      - run: npm run build --workspace=packages/shared-utils
-      - run: npm run build --workspace=packages/app
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-        working-directory: packages/e2e
-      - name: Run Free Mode E2E Tests
-        run: npm run test:free --workspace=packages/e2e
-        env:
-          E2E_MODE: 'free'
-          NEXT_PUBLIC_MOCK_MODE: 'false'
-          TEST_OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
-          TEST_ANTHROPIC_API_KEY: ${{ secrets.TEST_ANTHROPIC_API_KEY }}
-          TEST_GOOGLE_API_KEY: ${{ secrets.TEST_GOOGLE_API_KEY }}
-          TEST_XAI_API_KEY: ${{ secrets.TEST_XAI_API_KEY }}
-
-  # Pro Mode E2E Tests - Placeholder for Phase 4
-  # Will test backend services, authentication, and credits
-  # app-e2e-pro:
-  #   name: App E2E (Pro Mode)
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - run: echo "Pro mode tests will be added in Phase 4"
+  # Note: Free Mode and Pro Mode E2E tests run post-deployment in deploy.yml
+  # They test against the actual deployed infrastructure
 
   analysis:
     name: Static Analysis

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,3 +93,60 @@ jobs:
           echo "## Deployment Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Deployed to: https://ensemble-ai-prod--${{ vars.FIREBASE_PROJECT_ID }}.us-central1.hosted.app" >> $GITHUB_STEP_SUMMARY
+
+    outputs:
+      deploy_url: https://ensemble-ai-prod--${{ vars.FIREBASE_PROJECT_ID }}.us-central1.hosted.app
+
+  # Post-deployment E2E tests run against the actual deployed infrastructure
+  # These tests verify the real deployment works correctly
+  e2e-free-mode:
+    name: E2E Tests (Free Mode) - Post Deploy
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    if: ${{ needs.deploy.result == 'success' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: packages/e2e
+
+      - name: Run Free Mode E2E Tests against deployed app
+        run: npm run test:free --workspace=packages/e2e
+        env:
+          E2E_MODE: 'free'
+          E2E_BASE_URL: ${{ needs.deploy.outputs.deploy_url }}
+          NEXT_PUBLIC_MOCK_MODE: 'false'
+          TEST_OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
+          TEST_ANTHROPIC_API_KEY: ${{ secrets.TEST_ANTHROPIC_API_KEY }}
+          TEST_GOOGLE_API_KEY: ${{ secrets.TEST_GOOGLE_API_KEY }}
+          TEST_XAI_API_KEY: ${{ secrets.TEST_XAI_API_KEY }}
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: e2e-free-mode-results
+          path: packages/e2e/test-results/
+          retention-days: 7
+
+  # Pro Mode E2E Tests - Placeholder for Phase 4
+  # Will test backend services, authentication, and credits
+  # e2e-pro-mode:
+  #   name: E2E Tests (Pro Mode) - Post Deploy
+  #   runs-on: ubuntu-latest
+  #   needs: [deploy]
+  #   if: ${{ needs.deploy.result == 'success' }}
+  #   steps:
+  #     - run: echo "Pro mode tests will be added in Phase 4"


### PR DESCRIPTION
## Summary

Restructures the CI/CD pipeline to follow a **deploy-then-test** pattern for E2E tests:

1. **CI checks run first** (on PRs and main):
   - Component Library tests
   - Shared Utils tests
   - App lint/typecheck/build
   - **Mock Mode E2E tests** (UI validation with mock APIs)
   - Static Analysis

2. **Deploy to Firebase** (only on main, only if CI passes)

3. **Post-deploy E2E tests** (only if deploy succeeds):
   - **Free Mode E2E** (tests against deployed URL with real APIs)
   - Pro Mode E2E (placeholder for Phase 4)

## Changes

### CI workflow (ci.yml)
- Mock mode E2E tests remain in CI (run before deployment)
- Removed free mode E2E tests (now run post-deploy)

### Deploy workflow (deploy.yml)
- Added `e2e-free-mode` job that runs after deployment
- Tests use `E2E_BASE_URL` to target deployed app
- Uploads test artifacts on failure

### Playwright config
- Added `E2E_BASE_URL` support for testing deployed infrastructure
- When set, webServer is not started (tests run against remote URL)

### Documentation (CLAUDE.md)
- Added CI/CD pipeline flow diagram
- Documented E2E_BASE_URL environment variable

## Why this pattern?

- Mock mode tests verify UI works without external dependencies
- Free/Pro mode tests verify deployed app works with real infrastructure
- Catches deployment-specific issues that local tests miss

## Test plan

- [x] Mock mode E2E tests pass locally (68 tests)
- [x] Pre-commit hooks pass
- [ ] CI checks pass
- [ ] Deployment succeeds
- [ ] Post-deploy E2E tests run (will skip if no API keys configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)