### PR TITLE
feat: add confirmation step to Clear All Data button

### DIFF
--- a/packages/component-library/src/lib/i18n/locales/en.json
+++ b/packages/component-library/src/lib/i18n/locales/en.json
@@ -173,6 +173,9 @@
       "dangerZone": "Danger Zone",
       "dangerZoneWarning": "These actions cannot be undone.",
       "clearAllData": "Clear All Data",
+      "clearConfirmMessage": "Are you sure? This will permanently delete all your settings, API keys, and saved ensembles.",
+      "clearConfirmYes": "Yes, clear all data",
+      "clearConfirmCancel": "Cancel",
       "doneButton": "Done"
     },
     "workflowNavigator": {

--- a/packages/component-library/src/lib/i18n/locales/fr.json
+++ b/packages/component-library/src/lib/i18n/locales/fr.json
@@ -168,6 +168,9 @@
       "dangerZone": "Zone de Danger",
       "dangerZoneWarning": "Ces actions sont irréversibles.",
       "clearAllData": "Effacer Toutes les Données",
+      "clearConfirmMessage": "Êtes-vous sûr ? Cela supprimera définitivement tous vos paramètres, clés API et ensembles enregistrés.",
+      "clearConfirmYes": "Oui, tout effacer",
+      "clearConfirmCancel": "Annuler",
       "doneButton": "Terminé"
     },
     "workflowNavigator": {


### PR DESCRIPTION
## Summary
- Clicking "Clear All Data" in Settings now shows a warning message asking for confirmation before proceeding
- Cancel button returns to the initial button state
- Confirmation state resets automatically when the modal closes
- Added i18n translations for EN and FR

## Test plan
- [x] 36 SettingsModal unit tests pass (5 new tests for confirmation flow)
- [x] Component library lint passes
- [x] App lint + typecheck passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)