### PR TITLE
fix: vertically center stepper connector lines with step circles

### DIFF
--- a/packages/component-library/src/components/molecules/ProgressSteps/ProgressSteps.test.tsx
+++ b/packages/component-library/src/components/molecules/ProgressSteps/ProgressSteps.test.tsx
@@ -14,8 +14,8 @@ describe('ProgressSteps', () => {
 
   it('highlights the current step', () => {
     render(<ProgressSteps currentStep="prompt" />);
-    const promptStep = screen.getByText('Prompt').parentElement;
-    expect(promptStep?.querySelector('.bg-primary')).toBeInTheDocument();
+    const promptStep = screen.getByTestId('workflow-step-prompt');
+    expect(promptStep).toHaveClass('bg-primary');
   });
 
   it('shows check marks for completed steps', () => {

--- a/packages/component-library/src/components/molecules/ProgressSteps/ProgressSteps.tsx
+++ b/packages/component-library/src/components/molecules/ProgressSteps/ProgressSteps.tsx
@@ -39,22 +39,20 @@ export function ProgressSteps({ currentStep, fallbackStep }: ProgressStepsProps)
   const currentIndex = getCurrentStepIndex();
 
   return (
-    <div className="progress-steps flex items-center justify-center mb-12">
-      {steps.map((step, index) => (
-        <div key={step.id} className="flex items-center">
-          <div
-            className="flex flex-col items-center"
-            data-testid={`progress-step-${step.id}`}
-            data-active={index === currentIndex}
-            data-completed={index < currentIndex}
-          >
+    <div className="progress-steps flex flex-col items-center mb-12">
+      {/* Circles and connectors row */}
+      <div className="flex items-center">
+        {steps.map((step, index) => (
+          <div key={step.id} className="flex items-center">
             <div
-              className="flex flex-col items-center"
-              data-testid={`workflow-step-${step.id}`}
+              data-testid={`progress-step-${step.id}`}
               data-active={index === currentIndex}
               data-completed={index < currentIndex}
             >
               <div
+                data-testid={`workflow-step-${step.id}`}
+                data-active={index === currentIndex}
+                data-completed={index < currentIndex}
                 className={`w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors ${
                   index < currentIndex
                     ? 'bg-success text-success-foreground'
@@ -69,31 +67,36 @@ export function ProgressSteps({ currentStep, fallbackStep }: ProgressStepsProps)
                   step.number
                 )}
               </div>
-              <span
-                className={`mt-2 text-sm font-medium transition-colors ${
-                  index < currentIndex
-                    ? 'text-success'
-                    : index === currentIndex
-                      ? 'text-primary'
-                      : 'text-muted-foreground'
-                }`}
-              >
-                {step.label}
-              </span>
             </div>
+            {index < steps.length - 1 && (
+              <div
+                className={`w-16 h-0.5 mx-4 transition-colors ${
+                  index < currentIndex ? 'bg-success' : 'bg-muted'
+                }`}
+              />
+            )}
           </div>
-
-          {index < steps.length - 1 && (
-            <div
-              className={`w-16 h-0.5 mx-4 transition-colors ${
+        ))}
+      </div>
+      {/* Labels row */}
+      <div className="flex items-start mt-2">
+        {steps.map((step, index) => (
+          <div key={step.id} className="flex items-center">
+            <span
+              className={`w-12 text-center text-sm font-medium transition-colors ${
                 index < currentIndex
-                  ? 'bg-success'
-                  : 'bg-muted'
+                  ? 'text-success'
+                  : index === currentIndex
+                    ? 'text-primary'
+                    : 'text-muted-foreground'
               }`}
-            />
-          )}
-        </div>
-      ))}
+            >
+              {step.label}
+            </span>
+            {index < steps.length - 1 && <div className="w-16 mx-4" />}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/packages/component-library/src/components/molecules/ProgressSteps/__snapshots__/ProgressSteps.snapshot.test.tsx.snap
+++ b/packages/component-library/src/components/molecules/ProgressSteps/__snapshots__/ProgressSteps.snapshot.test.tsx.snap
@@ -2,127 +2,140 @@
 
 exports[`ProgressSteps Snapshots > matches snapshot for config step 1`] = `
 <div
-  class="progress-steps flex items-center justify-center mb-12"
+  class="progress-steps flex flex-col items-center mb-12"
 >
   <div
     class="flex items-center"
   >
     <div
-      class="flex flex-col items-center"
-      data-active="true"
-      data-completed="false"
-      data-testid="progress-step-config"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="true"
         data-completed="false"
-        data-testid="workflow-step-config"
+        data-testid="progress-step-config"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-primary text-primary-foreground"
+          data-active="true"
+          data-completed="false"
+          data-testid="workflow-step-config"
         >
           1
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-primary"
-        >
-          Config
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-muted"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="false"
-      data-testid="progress-step-ensemble"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="false"
-        data-testid="workflow-step-ensemble"
+        data-testid="progress-step-ensemble"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-muted text-muted-foreground"
+          data-active="false"
+          data-completed="false"
+          data-testid="workflow-step-ensemble"
         >
           2
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-muted-foreground"
-        >
-          Ensemble
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-muted"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="false"
-      data-testid="progress-step-prompt"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="false"
-        data-testid="workflow-step-prompt"
+        data-testid="progress-step-prompt"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-muted text-muted-foreground"
+          data-active="false"
+          data-completed="false"
+          data-testid="workflow-step-prompt"
         >
           3
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-muted-foreground"
-        >
-          Prompt
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-muted"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="false"
-      data-testid="progress-step-review"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="false"
-        data-testid="workflow-step-review"
+        data-testid="progress-step-review"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-muted text-muted-foreground"
+          data-active="false"
+          data-completed="false"
+          data-testid="workflow-step-review"
         >
           4
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-muted-foreground"
-        >
-          Review
-        </span>
       </div>
+    </div>
+  </div>
+  <div
+    class="flex items-start mt-2"
+  >
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-primary"
+      >
+        Config
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+      >
+        Ensemble
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+      >
+        Prompt
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+      >
+        Review
+      </span>
     </div>
   </div>
 </div>
@@ -130,25 +143,24 @@ exports[`ProgressSteps Snapshots > matches snapshot for config step 1`] = `
 
 exports[`ProgressSteps Snapshots > matches snapshot for ensemble step 1`] = `
 <div
-  class="progress-steps flex items-center justify-center mb-12"
+  class="progress-steps flex flex-col items-center mb-12"
 >
   <div
     class="flex items-center"
   >
     <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="true"
-      data-testid="progress-step-config"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="true"
-        data-testid="workflow-step-config"
+        data-testid="progress-step-config"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-success text-success-foreground"
+          data-active="false"
+          data-completed="true"
+          data-testid="workflow-step-config"
         >
           <svg
             class="lucide lucide-check w-4 h-4"
@@ -168,105 +180,119 @@ exports[`ProgressSteps Snapshots > matches snapshot for ensemble step 1`] = `
             />
           </svg>
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-success"
-        >
-          Config
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-success"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-success"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="true"
-      data-completed="false"
-      data-testid="progress-step-ensemble"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="true"
         data-completed="false"
-        data-testid="workflow-step-ensemble"
+        data-testid="progress-step-ensemble"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-primary text-primary-foreground"
+          data-active="true"
+          data-completed="false"
+          data-testid="workflow-step-ensemble"
         >
           2
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-primary"
-        >
-          Ensemble
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-muted"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="false"
-      data-testid="progress-step-prompt"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="false"
-        data-testid="workflow-step-prompt"
+        data-testid="progress-step-prompt"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-muted text-muted-foreground"
+          data-active="false"
+          data-completed="false"
+          data-testid="workflow-step-prompt"
         >
           3
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-muted-foreground"
-        >
-          Prompt
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-muted"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="false"
-      data-testid="progress-step-review"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="false"
-        data-testid="workflow-step-review"
+        data-testid="progress-step-review"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-muted text-muted-foreground"
+          data-active="false"
+          data-completed="false"
+          data-testid="workflow-step-review"
         >
           4
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-muted-foreground"
-        >
-          Review
-        </span>
       </div>
+    </div>
+  </div>
+  <div
+    class="flex items-start mt-2"
+  >
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-success"
+      >
+        Config
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-primary"
+      >
+        Ensemble
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+      >
+        Prompt
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+      >
+        Review
+      </span>
     </div>
   </div>
 </div>
@@ -274,25 +300,24 @@ exports[`ProgressSteps Snapshots > matches snapshot for ensemble step 1`] = `
 
 exports[`ProgressSteps Snapshots > matches snapshot for prompt step 1`] = `
 <div
-  class="progress-steps flex items-center justify-center mb-12"
+  class="progress-steps flex flex-col items-center mb-12"
 >
   <div
     class="flex items-center"
   >
     <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="true"
-      data-testid="progress-step-config"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="true"
-        data-testid="workflow-step-config"
+        data-testid="progress-step-config"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-success text-success-foreground"
+          data-active="false"
+          data-completed="true"
+          data-testid="workflow-step-config"
         >
           <svg
             class="lucide lucide-check w-4 h-4"
@@ -312,34 +337,24 @@ exports[`ProgressSteps Snapshots > matches snapshot for prompt step 1`] = `
             />
           </svg>
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-success"
-        >
-          Config
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-success"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-success"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="true"
-      data-testid="progress-step-ensemble"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="true"
-        data-testid="workflow-step-ensemble"
+        data-testid="progress-step-ensemble"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-success text-success-foreground"
+          data-active="false"
+          data-completed="true"
+          data-testid="workflow-step-ensemble"
         >
           <svg
             class="lucide lucide-check w-4 h-4"
@@ -359,74 +374,98 @@ exports[`ProgressSteps Snapshots > matches snapshot for prompt step 1`] = `
             />
           </svg>
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-success"
-        >
-          Ensemble
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-success"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-success"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="true"
-      data-completed="false"
-      data-testid="progress-step-prompt"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="true"
         data-completed="false"
-        data-testid="workflow-step-prompt"
+        data-testid="progress-step-prompt"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-primary text-primary-foreground"
+          data-active="true"
+          data-completed="false"
+          data-testid="workflow-step-prompt"
         >
           3
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-primary"
-        >
-          Prompt
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-muted"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="false"
-      data-testid="progress-step-review"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="false"
-        data-testid="workflow-step-review"
+        data-testid="progress-step-review"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-muted text-muted-foreground"
+          data-active="false"
+          data-completed="false"
+          data-testid="workflow-step-review"
         >
           4
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-muted-foreground"
-        >
-          Review
-        </span>
       </div>
+    </div>
+  </div>
+  <div
+    class="flex items-start mt-2"
+  >
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-success"
+      >
+        Config
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-success"
+      >
+        Ensemble
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-primary"
+      >
+        Prompt
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+      >
+        Review
+      </span>
     </div>
   </div>
 </div>
@@ -434,25 +473,24 @@ exports[`ProgressSteps Snapshots > matches snapshot for prompt step 1`] = `
 
 exports[`ProgressSteps Snapshots > matches snapshot for review step 1`] = `
 <div
-  class="progress-steps flex items-center justify-center mb-12"
+  class="progress-steps flex flex-col items-center mb-12"
 >
   <div
     class="flex items-center"
   >
     <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="true"
-      data-testid="progress-step-config"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="true"
-        data-testid="workflow-step-config"
+        data-testid="progress-step-config"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-success text-success-foreground"
+          data-active="false"
+          data-completed="true"
+          data-testid="workflow-step-config"
         >
           <svg
             class="lucide lucide-check w-4 h-4"
@@ -472,34 +510,24 @@ exports[`ProgressSteps Snapshots > matches snapshot for review step 1`] = `
             />
           </svg>
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-success"
-        >
-          Config
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-success"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-success"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="true"
-      data-testid="progress-step-ensemble"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="true"
-        data-testid="workflow-step-ensemble"
+        data-testid="progress-step-ensemble"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-success text-success-foreground"
+          data-active="false"
+          data-completed="true"
+          data-testid="workflow-step-ensemble"
         >
           <svg
             class="lucide lucide-check w-4 h-4"
@@ -519,34 +547,24 @@ exports[`ProgressSteps Snapshots > matches snapshot for review step 1`] = `
             />
           </svg>
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-success"
-        >
-          Ensemble
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-success"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-success"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="true"
-      data-testid="progress-step-prompt"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="true"
-        data-testid="workflow-step-prompt"
+        data-testid="progress-step-prompt"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-success text-success-foreground"
+          data-active="false"
+          data-completed="true"
+          data-testid="workflow-step-prompt"
         >
           <svg
             class="lucide lucide-check w-4 h-4"
@@ -566,43 +584,77 @@ exports[`ProgressSteps Snapshots > matches snapshot for review step 1`] = `
             />
           </svg>
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-success"
-        >
-          Prompt
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-success"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-success"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="true"
-      data-completed="false"
-      data-testid="progress-step-review"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="true"
         data-completed="false"
-        data-testid="workflow-step-review"
+        data-testid="progress-step-review"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-primary text-primary-foreground"
+          data-active="true"
+          data-completed="false"
+          data-testid="workflow-step-review"
         >
           4
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-primary"
-        >
-          Review
-        </span>
       </div>
+    </div>
+  </div>
+  <div
+    class="flex items-start mt-2"
+  >
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-success"
+      >
+        Config
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-success"
+      >
+        Ensemble
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-success"
+      >
+        Prompt
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-primary"
+      >
+        Review
+      </span>
     </div>
   </div>
 </div>

--- a/packages/component-library/src/components/molecules/ProgressSteps/__snapshots__/ProgressSteps.test.tsx.snap
+++ b/packages/component-library/src/components/molecules/ProgressSteps/__snapshots__/ProgressSteps.test.tsx.snap
@@ -2,127 +2,140 @@
 
 exports[`ProgressSteps > snapshots > matches snapshot for config step 1`] = `
 <div
-  class="progress-steps flex items-center justify-center mb-12"
+  class="progress-steps flex flex-col items-center mb-12"
 >
   <div
     class="flex items-center"
   >
     <div
-      class="flex flex-col items-center"
-      data-active="true"
-      data-completed="false"
-      data-testid="progress-step-config"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="true"
         data-completed="false"
-        data-testid="workflow-step-config"
+        data-testid="progress-step-config"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-primary text-primary-foreground"
+          data-active="true"
+          data-completed="false"
+          data-testid="workflow-step-config"
         >
           1
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-primary"
-        >
-          Config
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-muted"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="false"
-      data-testid="progress-step-ensemble"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="false"
-        data-testid="workflow-step-ensemble"
+        data-testid="progress-step-ensemble"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-muted text-muted-foreground"
+          data-active="false"
+          data-completed="false"
+          data-testid="workflow-step-ensemble"
         >
           2
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-muted-foreground"
-        >
-          Ensemble
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-muted"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="false"
-      data-testid="progress-step-prompt"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="false"
-        data-testid="workflow-step-prompt"
+        data-testid="progress-step-prompt"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-muted text-muted-foreground"
+          data-active="false"
+          data-completed="false"
+          data-testid="workflow-step-prompt"
         >
           3
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-muted-foreground"
-        >
-          Prompt
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-muted"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="false"
-      data-testid="progress-step-review"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="false"
-        data-testid="workflow-step-review"
+        data-testid="progress-step-review"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-muted text-muted-foreground"
+          data-active="false"
+          data-completed="false"
+          data-testid="workflow-step-review"
         >
           4
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-muted-foreground"
-        >
-          Review
-        </span>
       </div>
+    </div>
+  </div>
+  <div
+    class="flex items-start mt-2"
+  >
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-primary"
+      >
+        Config
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+      >
+        Ensemble
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+      >
+        Prompt
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+      >
+        Review
+      </span>
     </div>
   </div>
 </div>
@@ -130,25 +143,24 @@ exports[`ProgressSteps > snapshots > matches snapshot for config step 1`] = `
 
 exports[`ProgressSteps > snapshots > matches snapshot for ensemble step 1`] = `
 <div
-  class="progress-steps flex items-center justify-center mb-12"
+  class="progress-steps flex flex-col items-center mb-12"
 >
   <div
     class="flex items-center"
   >
     <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="true"
-      data-testid="progress-step-config"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="true"
-        data-testid="workflow-step-config"
+        data-testid="progress-step-config"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-success text-success-foreground"
+          data-active="false"
+          data-completed="true"
+          data-testid="workflow-step-config"
         >
           <svg
             class="lucide lucide-check w-4 h-4"
@@ -168,105 +180,119 @@ exports[`ProgressSteps > snapshots > matches snapshot for ensemble step 1`] = `
             />
           </svg>
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-success"
-        >
-          Config
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-success"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-success"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="true"
-      data-completed="false"
-      data-testid="progress-step-ensemble"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="true"
         data-completed="false"
-        data-testid="workflow-step-ensemble"
+        data-testid="progress-step-ensemble"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-primary text-primary-foreground"
+          data-active="true"
+          data-completed="false"
+          data-testid="workflow-step-ensemble"
         >
           2
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-primary"
-        >
-          Ensemble
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-muted"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="false"
-      data-testid="progress-step-prompt"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="false"
-        data-testid="workflow-step-prompt"
+        data-testid="progress-step-prompt"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-muted text-muted-foreground"
+          data-active="false"
+          data-completed="false"
+          data-testid="workflow-step-prompt"
         >
           3
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-muted-foreground"
-        >
-          Prompt
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-muted"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="false"
-      data-testid="progress-step-review"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="false"
-        data-testid="workflow-step-review"
+        data-testid="progress-step-review"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-muted text-muted-foreground"
+          data-active="false"
+          data-completed="false"
+          data-testid="workflow-step-review"
         >
           4
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-muted-foreground"
-        >
-          Review
-        </span>
       </div>
+    </div>
+  </div>
+  <div
+    class="flex items-start mt-2"
+  >
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-success"
+      >
+        Config
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-primary"
+      >
+        Ensemble
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+      >
+        Prompt
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+      >
+        Review
+      </span>
     </div>
   </div>
 </div>
@@ -274,25 +300,24 @@ exports[`ProgressSteps > snapshots > matches snapshot for ensemble step 1`] = `
 
 exports[`ProgressSteps > snapshots > matches snapshot for prompt step 1`] = `
 <div
-  class="progress-steps flex items-center justify-center mb-12"
+  class="progress-steps flex flex-col items-center mb-12"
 >
   <div
     class="flex items-center"
   >
     <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="true"
-      data-testid="progress-step-config"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="true"
-        data-testid="workflow-step-config"
+        data-testid="progress-step-config"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-success text-success-foreground"
+          data-active="false"
+          data-completed="true"
+          data-testid="workflow-step-config"
         >
           <svg
             class="lucide lucide-check w-4 h-4"
@@ -312,34 +337,24 @@ exports[`ProgressSteps > snapshots > matches snapshot for prompt step 1`] = `
             />
           </svg>
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-success"
-        >
-          Config
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-success"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-success"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="true"
-      data-testid="progress-step-ensemble"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="true"
-        data-testid="workflow-step-ensemble"
+        data-testid="progress-step-ensemble"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-success text-success-foreground"
+          data-active="false"
+          data-completed="true"
+          data-testid="workflow-step-ensemble"
         >
           <svg
             class="lucide lucide-check w-4 h-4"
@@ -359,74 +374,98 @@ exports[`ProgressSteps > snapshots > matches snapshot for prompt step 1`] = `
             />
           </svg>
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-success"
-        >
-          Ensemble
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-success"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-success"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="true"
-      data-completed="false"
-      data-testid="progress-step-prompt"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="true"
         data-completed="false"
-        data-testid="workflow-step-prompt"
+        data-testid="progress-step-prompt"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-primary text-primary-foreground"
+          data-active="true"
+          data-completed="false"
+          data-testid="workflow-step-prompt"
         >
           3
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-primary"
-        >
-          Prompt
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-muted"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="false"
-      data-testid="progress-step-review"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="false"
-        data-testid="workflow-step-review"
+        data-testid="progress-step-review"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-muted text-muted-foreground"
+          data-active="false"
+          data-completed="false"
+          data-testid="workflow-step-review"
         >
           4
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-muted-foreground"
-        >
-          Review
-        </span>
       </div>
+    </div>
+  </div>
+  <div
+    class="flex items-start mt-2"
+  >
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-success"
+      >
+        Config
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-success"
+      >
+        Ensemble
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-primary"
+      >
+        Prompt
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+      >
+        Review
+      </span>
     </div>
   </div>
 </div>
@@ -434,25 +473,24 @@ exports[`ProgressSteps > snapshots > matches snapshot for prompt step 1`] = `
 
 exports[`ProgressSteps > snapshots > matches snapshot for review step 1`] = `
 <div
-  class="progress-steps flex items-center justify-center mb-12"
+  class="progress-steps flex flex-col items-center mb-12"
 >
   <div
     class="flex items-center"
   >
     <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="true"
-      data-testid="progress-step-config"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="true"
-        data-testid="workflow-step-config"
+        data-testid="progress-step-config"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-success text-success-foreground"
+          data-active="false"
+          data-completed="true"
+          data-testid="workflow-step-config"
         >
           <svg
             class="lucide lucide-check w-4 h-4"
@@ -472,34 +510,24 @@ exports[`ProgressSteps > snapshots > matches snapshot for review step 1`] = `
             />
           </svg>
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-success"
-        >
-          Config
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-success"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-success"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="true"
-      data-testid="progress-step-ensemble"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="true"
-        data-testid="workflow-step-ensemble"
+        data-testid="progress-step-ensemble"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-success text-success-foreground"
+          data-active="false"
+          data-completed="true"
+          data-testid="workflow-step-ensemble"
         >
           <svg
             class="lucide lucide-check w-4 h-4"
@@ -519,34 +547,24 @@ exports[`ProgressSteps > snapshots > matches snapshot for review step 1`] = `
             />
           </svg>
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-success"
-        >
-          Ensemble
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-success"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-success"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="false"
-      data-completed="true"
-      data-testid="progress-step-prompt"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="false"
         data-completed="true"
-        data-testid="workflow-step-prompt"
+        data-testid="progress-step-prompt"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-success text-success-foreground"
+          data-active="false"
+          data-completed="true"
+          data-testid="workflow-step-prompt"
         >
           <svg
             class="lucide lucide-check w-4 h-4"
@@ -566,43 +584,77 @@ exports[`ProgressSteps > snapshots > matches snapshot for review step 1`] = `
             />
           </svg>
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-success"
-        >
-          Prompt
-        </span>
       </div>
+      <div
+        class="w-16 h-0.5 mx-4 transition-colors bg-success"
+      />
     </div>
     <div
-      class="w-16 h-0.5 mx-4 transition-colors bg-success"
-    />
-  </div>
-  <div
-    class="flex items-center"
-  >
-    <div
-      class="flex flex-col items-center"
-      data-active="true"
-      data-completed="false"
-      data-testid="progress-step-review"
+      class="flex items-center"
     >
       <div
-        class="flex flex-col items-center"
         data-active="true"
         data-completed="false"
-        data-testid="workflow-step-review"
+        data-testid="progress-step-review"
       >
         <div
           class="w-12 h-12 rounded-full flex items-center justify-center font-semibold text-sm transition-colors bg-primary text-primary-foreground"
+          data-active="true"
+          data-completed="false"
+          data-testid="workflow-step-review"
         >
           4
         </div>
-        <span
-          class="mt-2 text-sm font-medium transition-colors text-primary"
-        >
-          Review
-        </span>
       </div>
+    </div>
+  </div>
+  <div
+    class="flex items-start mt-2"
+  >
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-success"
+      >
+        Config
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-success"
+      >
+        Ensemble
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-success"
+      >
+        Prompt
+      </span>
+      <div
+        class="w-16 mx-4"
+      />
+    </div>
+    <div
+      class="flex items-center"
+    >
+      <span
+        class="w-12 text-center text-sm font-medium transition-colors text-primary"
+      >
+        Review
+      </span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Separate the stepper into two rows: circles+connectors on top, labels below
- Connector lines now align with circle centers instead of being offset by label height
- The previous layout had circles and labels in a single flex-col per step, causing connectors (aligned via `items-center`) to center against the full circle+label height

Closes #35

## Test plan
- [x] 22 ProgressSteps tests pass (updated 1 test to use data-testid)
- [x] Snapshots updated for new DOM structure
- [x] Component library lint passes
- [x] App lint + typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)