### PR TITLE
refactor: remove unused code in useEnsemblePage

### DIFF
--- a/packages/app/src/app/ensemble/hooks/useEnsemblePage.ts
+++ b/packages/app/src/app/ensemble/hooks/useEnsemblePage.ts
@@ -110,8 +110,6 @@ export function useEnsemblePage() {
         validateApiKey
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const _removeManualResponse = useStore((state) => state.removeManualResponse);
     const setConsensusMethod = useStore((state) => state.setConsensusMethod);
     const setEloTopN = useStore((state) => state.setEloTopN);
     const consensusMethod = useStore((state) => state.consensusMethod);


### PR DESCRIPTION
## Summary
- Removed unused `_removeManualResponse` variable and its `eslint-disable` comment from `useEnsemblePage.ts`

The variable was pulled from the Zustand store but never used in any handler or return value.

## Test plan
- [x] App lint + typecheck pass
- [x] Pre-commit hooks pass

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)