### PR TITLE
ci: cache Playwright browsers between CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,23 @@ jobs:
       - run: npm ci
       - run: npm run lint --workspace=packages/component-library
       - run: npm run test:unit --workspace=packages/component-library
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+        working-directory: packages/component-library
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+        working-directory: packages/component-library
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
         working-directory: packages/component-library
       - run: npm run test:storybook:ci --workspace=packages/component-library
 
@@ -71,8 +86,23 @@ jobs:
       - run: npm ci
       - run: npm run build --workspace=packages/shared-utils
       - run: npm run build --workspace=packages/app
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+        working-directory: packages/e2e
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+        working-directory: packages/e2e
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
         working-directory: packages/e2e
       - name: Run Mock Mode E2E Tests
         run: npm run test:mock --workspace=packages/e2e

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,8 +124,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+        working-directory: packages/e2e
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+        working-directory: packages/e2e
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
         working-directory: packages/e2e
 
       - name: Run Free Mode E2E Tests against deployed app


### PR DESCRIPTION
## Summary
- Cache `~/.cache/ms-playwright` keyed by OS + Playwright version across all 3 jobs that install Playwright browsers
- On cache hit: skip browser download, only install system deps (`playwright install-deps`)
- On cache miss: full install with `playwright install --with-deps`

Fixes #74

## How it works

1. Get Playwright version via `npx playwright --version`
2. Cache key: `playwright-{os}-{version}` — invalidates automatically on Playwright upgrades
3. On hit: browsers already in cache, just need OS-level dependencies (`install-deps`)
4. On miss: full download + system deps (`install --with-deps`)

Applied to:
- **Component Library** job (Storybook tests)
- **App E2E Mock Mode** job
- **E2E Free Mode** job (deploy.yml)

## Test plan
- [ ] CI runs successfully with cache miss (first run)
- [ ] Subsequent CI runs hit the cache and skip browser download

🤖 Generated with [Claude Code](https://claude.com/claude-code)