### PR TITLE
design: replace teal/cyan accent with violet to harmonise with purple primary (#46)

### DIFF
--- a/packages/app/src/styles/globals.css
+++ b/packages/app/src/styles/globals.css
@@ -17,8 +17,8 @@
     --color-secondary-foreground: 15 23 42;
     --color-muted: 241 245 249;
     --color-muted-foreground: 100 116 139;
-    --color-accent: 6 182 212;
-    --color-accent-foreground: 15 23 42;
+    --color-accent: 237 233 254;
+    --color-accent-foreground: 67 56 202;
     --color-destructive: 220 38 38;
     --color-destructive-foreground: 255 255 255;
     --color-success: 34 197 94;
@@ -45,8 +45,8 @@
     --color-secondary-foreground: 241 245 249;
     --color-muted: 30 30 50;
     --color-muted-foreground: 148 163 184;
-    --color-accent: 34 211 238;
-    --color-accent-foreground: 15 15 25;
+    --color-accent: 46 39 82;
+    --color-accent-foreground: 224 231 255;
     --color-destructive: 239 68 68;
     --color-destructive-foreground: 255 255 255;
     --color-success: 74 222 128;

--- a/packages/component-library/src/styles/globals.css
+++ b/packages/component-library/src/styles/globals.css
@@ -16,8 +16,8 @@
     --color-secondary-foreground: 15 23 42;
     --color-muted: 241 245 249;
     --color-muted-foreground: 100 116 139;
-    --color-accent: 6 182 212;
-    --color-accent-foreground: 15 23 42;
+    --color-accent: 237 233 254;
+    --color-accent-foreground: 67 56 202;
     --color-destructive: 220 38 38;
     --color-destructive-foreground: 255 255 255;
     --color-success: 34 197 94;
@@ -43,8 +43,8 @@
     --color-secondary-foreground: 241 245 249;
     --color-muted: 30 30 50;
     --color-muted-foreground: 148 163 184;
-    --color-accent: 34 211 238;
-    --color-accent-foreground: 15 15 25;
+    --color-accent: 46 39 82;
+    --color-accent-foreground: 224 231 255;
     --color-destructive: 239 68 68;
     --color-destructive-foreground: 255 255 255;
     --color-success: 74 222 128;


### PR DESCRIPTION
## Summary
- Fixes #46 — the teal/cyan accent colour clashed with the purple primary palette
- Replaced accent colour with soft violet tones from the same colour family:
  - **Light mode**: `#ede9fe` (violet-100) background, `#4338ca` (indigo-700) foreground
  - **Dark mode**: `#2e2752` (deep violet) background, `#e0e7ff` (indigo-100) foreground
- Updated both `packages/app` and `packages/component-library` globals.css
- Accent is used for hover/focus states on buttons, selects, model cards, and header controls

## Test plan
- [x] All 1022 component library tests pass
- [x] All 112 app tests pass
- [x] Lint + typecheck pass
- [x] Production build succeeds
- [ ] Visual review in Storybook (light + dark themes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)