### PR TITLE
fix: exclude non-chat-completions models from OpenAI model list

### DIFF
--- a/packages/shared-utils/src/providers/__tests__/free-clients.integration.test.ts
+++ b/packages/shared-utils/src/providers/__tests__/free-clients.integration.test.ts
@@ -78,6 +78,24 @@ describeIf(Boolean(openAiKey))('OpenAI Free client integration', () => {
     },
     20_000,
   );
+
+  it(
+    'excludes non-chat-completions models',
+    async () => {
+      const client = new FreeOpenAIClient('openai', () => openAiKey!);
+      const models = await client.listAvailableTextModels();
+      for (const id of models) {
+        expect(id).not.toMatch(/codex/);
+        expect(id).not.toMatch(/-pro($|-)/);
+        expect(id).not.toMatch(/realtime/);
+        expect(id).not.toMatch(/transcribe/);
+        expect(id).not.toMatch(/image/);
+        expect(id).not.toMatch(/instruct/);
+        expect(id).not.toMatch(/deep-research/);
+      }
+    },
+    20_000,
+  );
 });
 
 describeIf(Boolean(anthropicKey))('Anthropic Free client integration', () => {

--- a/packages/shared-utils/src/providers/clients/openai/FreeOpenAIClient.test.ts
+++ b/packages/shared-utils/src/providers/clients/openai/FreeOpenAIClient.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FreeOpenAIClient } from './FreeOpenAIClient.js';
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    openAiRetrieve: vi.fn(),
+    openAiList: vi.fn(),
+    openAiChatCreate: vi.fn(),
+  },
+}));
+
+vi.mock('openai', () => ({
+  default: class {
+    models = { retrieve: mocks.openAiRetrieve, list: mocks.openAiList };
+    chat = { completions: { create: mocks.openAiChatCreate } };
+  },
+}));
+
+describe('FreeOpenAIClient model filtering', () => {
+  beforeEach(() => {
+    mocks.openAiList.mockReset();
+  });
+
+  it('includes standard chat models', async () => {
+    mocks.openAiList.mockResolvedValueOnce({
+      data: [
+        { id: 'gpt-4o' },
+        { id: 'gpt-4o-mini' },
+        { id: 'gpt-4-turbo' },
+        { id: 'gpt-4.1' },
+        { id: 'gpt-4.1-mini' },
+        { id: 'gpt-4.1-nano' },
+        { id: 'gpt-3.5-turbo' },
+        { id: 'gpt-5' },
+        { id: 'gpt-5-mini' },
+        { id: 'gpt-5.2' },
+        { id: 'o1-preview' },
+        { id: 'o1-mini' },
+        { id: 'o3-mini' },
+      ],
+    });
+
+    const client = new FreeOpenAIClient('openai', () => 'sk-test');
+    const models = await client.listAvailableTextModels();
+
+    expect(models).toEqual([
+      'gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-4.1', 'gpt-4.1-mini',
+      'gpt-4.1-nano', 'gpt-3.5-turbo', 'gpt-5', 'gpt-5-mini', 'gpt-5.2',
+      'o1-preview', 'o1-mini', 'o3-mini',
+    ]);
+  });
+
+  it('excludes Responses API models (codex)', async () => {
+    mocks.openAiList.mockResolvedValueOnce({
+      data: [
+        { id: 'gpt-4o' },
+        { id: 'gpt-5-codex' },
+        { id: 'gpt-5.1-codex' },
+        { id: 'gpt-5.1-codex-max' },
+        { id: 'gpt-5.1-codex-mini' },
+        { id: 'gpt-5.2-codex' },
+      ],
+    });
+
+    const client = new FreeOpenAIClient('openai', () => 'sk-test');
+    const models = await client.listAvailableTextModels();
+    expect(models).toEqual(['gpt-4o']);
+  });
+
+  it('excludes -pro models (Responses API only)', async () => {
+    mocks.openAiList.mockResolvedValueOnce({
+      data: [
+        { id: 'gpt-4o' },
+        { id: 'gpt-5-pro' },
+        { id: 'gpt-5-pro-2025-10-06' },
+        { id: 'gpt-5.2-pro' },
+        { id: 'gpt-5.2-pro-2025-12-11' },
+        { id: 'o1-pro' },
+        { id: 'o1-pro-2025-03-19' },
+        { id: 'o3-pro' },
+        { id: 'o3-pro-2025-06-10' },
+      ],
+    });
+
+    const client = new FreeOpenAIClient('openai', () => 'sk-test');
+    const models = await client.listAvailableTextModels();
+    expect(models).toEqual(['gpt-4o']);
+  });
+
+  it('excludes realtime, transcribe, image, and deep-research models', async () => {
+    mocks.openAiList.mockResolvedValueOnce({
+      data: [
+        { id: 'gpt-4o' },
+        { id: 'gpt-4o-realtime-preview' },
+        { id: 'gpt-4o-realtime-preview-2024-12-17' },
+        { id: 'gpt-4o-transcribe' },
+        { id: 'gpt-4o-mini-transcribe-2025-03-20' },
+        { id: 'gpt-image-1' },
+        { id: 'gpt-image-1-mini' },
+        { id: 'gpt-realtime' },
+        { id: 'gpt-realtime-mini' },
+        { id: 'o3-deep-research' },
+        { id: 'o3-deep-research-2025-06-26' },
+      ],
+    });
+
+    const client = new FreeOpenAIClient('openai', () => 'sk-test');
+    const models = await client.listAvailableTextModels();
+    expect(models).toEqual(['gpt-4o']);
+  });
+
+  it('excludes instruct and legacy completions models', async () => {
+    mocks.openAiList.mockResolvedValueOnce({
+      data: [
+        { id: 'gpt-4o' },
+        { id: 'gpt-3.5-turbo-instruct' },
+        { id: 'gpt-3.5-turbo-instruct-0914' },
+        { id: 'davinci-002' },
+        { id: 'babbage-002' },
+      ],
+    });
+
+    const client = new FreeOpenAIClient('openai', () => 'sk-test');
+    const models = await client.listAvailableTextModels();
+    expect(models).toEqual(['gpt-4o']);
+  });
+
+  it('excludes non-text models (audio, tts, dall-e, whisper, embedding)', async () => {
+    mocks.openAiList.mockResolvedValueOnce({
+      data: [
+        { id: 'gpt-4o' },
+        { id: 'gpt-4o-audio-preview' },
+        { id: 'whisper-1' },
+        { id: 'dall-e-3' },
+        { id: 'tts-1-hd' },
+        { id: 'text-embedding-3-small' },
+      ],
+    });
+
+    const client = new FreeOpenAIClient('openai', () => 'sk-test');
+    const models = await client.listAvailableTextModels();
+    expect(models).toEqual(['gpt-4o']);
+  });
+
+  it('includes search-preview models (chat compatible)', async () => {
+    mocks.openAiList.mockResolvedValueOnce({
+      data: [
+        { id: 'gpt-4o-search-preview' },
+        { id: 'gpt-4o-mini-search-preview-2025-03-11' },
+        { id: 'gpt-5-search-api' },
+      ],
+    });
+
+    const client = new FreeOpenAIClient('openai', () => 'sk-test');
+    const models = await client.listAvailableTextModels();
+    expect(models).toEqual([
+      'gpt-4o-search-preview',
+      'gpt-4o-mini-search-preview-2025-03-11',
+      'gpt-5-search-api',
+    ]);
+  });
+
+  it('handles empty list and null IDs', async () => {
+    mocks.openAiList.mockResolvedValueOnce({
+      data: [{ id: null }, { id: undefined }, { id: '' }, { id: 'gpt-4o' }],
+    });
+
+    const client = new FreeOpenAIClient('openai', () => 'sk-test');
+    const models = await client.listAvailableTextModels();
+    expect(models).toEqual(['gpt-4o']);
+  });
+});

--- a/packages/shared-utils/src/providers/clients/openai/FreeOpenAIClient.ts
+++ b/packages/shared-utils/src/providers/clients/openai/FreeOpenAIClient.ts
@@ -36,16 +36,25 @@ export class FreeOpenAIClient extends BaseFreeClient {
       .map((model) => model.id)
       .filter((id): id is string => {
         if (!id) return false;
-        // Filter for known text generation model prefixes
-        const isTextModel = id.startsWith('gpt-') || id.startsWith('o1-') || id.startsWith('o3-');
-        // Explicitly exclude non-text capabilities
-        const isExcluded =
+        const isChatCandidate =
+          id.startsWith('gpt-') || id.startsWith('o1-') || id.startsWith('o3-');
+        if (!isChatCandidate) return false;
+        // Exclude models that don't support the Chat Completions endpoint.
+        // Patterns derived from probing the OpenAI API (404 = not chat).
+        const isNonChat =
           id.includes('audio') ||
           id.includes('tts') ||
           id.includes('dall-e') ||
           id.includes('whisper') ||
-          id.includes('embedding');
-        return isTextModel && !isExcluded;
+          id.includes('embedding') ||
+          id.includes('realtime') ||
+          id.includes('transcribe') ||
+          id.includes('image') ||
+          id.includes('codex') ||
+          id.includes('instruct') ||
+          id.includes('deep-research') ||
+          /-pro($|-)/.test(id);
+        return !isNonChat;
       });
   }
 


### PR DESCRIPTION
## Summary
- `gpt-5.2-pro`, `gpt-5.2-codex`, and other non-chat models were showing in model selection but failing with 404 when used (they don't support `/v1/chat/completions`)
- Replace the simple exclusion list with **pattern-based filtering** derived from systematically probing the OpenAI API — a 404 response means "not a chat model"
- New excluded patterns: `codex`, `-pro`, `realtime`, `transcribe`, `image`, `instruct`, `deep-research`
- This catches current AND future dated variants (e.g. `gpt-5.2-codex-2026-01-15`, `o4-pro`) automatically

Closes #85

## Test plan
- [x] 8 new unit tests covering all exclusion patterns + inclusion of valid models
- [x] New integration test verifies no excluded patterns in live OpenAI API response
- [x] All 76 unit tests pass, 13 integration tests pass with real keys
- [x] Lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)