### PR TITLE
fix: improve instructional text on Config page

### DIFF
--- a/packages/app/public/locales/en/common.json
+++ b/packages/app/public/locales/en/common.json
@@ -116,7 +116,7 @@
   "pages": {
     "config": {
       "title": "Configuration",
-      "description": "Choose your operating mode to get started with AI Ensemble",
+      "description": "Choose Free Mode to use your own API keys, or Pro Mode for managed access. Then continue to select your ensemble models.",
       "apiKeyInfoBold": "Configure an API key to continue.",
       "apiKeyInfoNormal": "Your keys are stored locally and never sent to our servers.",
       "apiKeysConfigured": "{{count}} API key configured.",

--- a/packages/app/public/locales/fr/common.json
+++ b/packages/app/public/locales/fr/common.json
@@ -108,7 +108,7 @@
   "pages": {
     "config": {
       "title": "Configuration",
-      "description": "Choisissez votre mode de fonctionnement pour commencer avec AI Ensemble",
+      "description": "Choisissez le mode Gratuit pour utiliser vos propres clés API, ou le mode Pro pour un accès géré. Continuez ensuite vers la sélection des modèles de votre ensemble.",
       "apiKeyInfoBold": "Configurez une clé API pour continuer.",
       "apiKeyInfoNormal": "Vos clés sont stockées localement et ne sont jamais envoyées à nos serveurs.",
       "apiKeysConfigured": "{{count}} clé API configurée.",

--- a/packages/e2e/tests/mock-mode/config-page.spec.ts
+++ b/packages/e2e/tests/mock-mode/config-page.spec.ts
@@ -31,6 +31,11 @@ test.describe('Config Page', () => {
 
     // Check for page hero heading (should be visible on the page)
     await expect(page.getByText(/configuration/i).first()).toBeVisible();
+    await expect(
+      page.getByText(
+        /Choose Free Mode to use your own API keys, or Pro Mode for managed access/i
+      )
+    ).toBeVisible();
 
     // Check for workflow navigator
     await expect(page.getByTestId('workflow-navigator')).toBeVisible();


### PR DESCRIPTION
## Summary\n- improve the Config page subtitle to clearly explain Free vs Pro mode choices\n- clarify what users do next in the workflow (continue to model selection)\n- add mock-mode config E2E coverage for the updated subtitle text\n\n## Files\n- packages/app/public/locales/en/common.json\n- packages/app/public/locales/fr/common.json\n- packages/e2e/tests/mock-mode/config-page.spec.ts\n\n## Validation\n- npm --workspace @ai-ensemble/e2e run test:mock -- tests/mock-mode/config-page.spec.ts\n\nCloses #106