### PR TITLE
fix: use info color for API keys configured alert

### DIFF
--- a/packages/app/src/styles/globals.css
+++ b/packages/app/src/styles/globals.css
@@ -25,6 +25,8 @@
     --color-success-foreground: 15 23 42;
     --color-warning: 245 158 11;
     --color-warning-foreground: 15 23 42;
+    --color-info: 59 130 246;
+    --color-info-foreground: 255 255 255;
     --color-border: 226 232 240;
     --color-input: 226 232 240;
     --color-ring: 79 70 229;
@@ -53,6 +55,8 @@
     --color-success-foreground: 15 15 25;
     --color-warning: 251 191 36;
     --color-warning-foreground: 15 15 25;
+    --color-info: 96 165 250;
+    --color-info-foreground: 15 15 25;
     --color-border: 40 40 65;
     --color-input: 40 40 65;
     --color-ring: 129 140 248;

--- a/packages/app/tailwind.config.ts
+++ b/packages/app/tailwind.config.ts
@@ -34,6 +34,10 @@ export default {
           DEFAULT: 'rgb(var(--color-warning) / <alpha-value>)',
           foreground: 'rgb(var(--color-warning-foreground) / <alpha-value>)',
         },
+        info: {
+          DEFAULT: 'rgb(var(--color-info) / <alpha-value>)',
+          foreground: 'rgb(var(--color-info-foreground) / <alpha-value>)',
+        },
         muted: {
           DEFAULT: 'rgb(var(--color-muted) / <alpha-value>)',
           foreground: 'rgb(var(--color-muted-foreground) / <alpha-value>)',

--- a/packages/component-library/src/components/atoms/InlineAlert/InlineAlert.test.tsx
+++ b/packages/component-library/src/components/atoms/InlineAlert/InlineAlert.test.tsx
@@ -14,7 +14,7 @@ describe('InlineAlert', () => {
     it('renders with info variant by default', () => {
       const { container } = render(<InlineAlert>Message</InlineAlert>);
       const alert = container.firstChild;
-      expect(alert).toHaveClass('bg-primary/10');
+      expect(alert).toHaveClass('bg-info/10');
     });
 
     it('renders with success variant', () => {
@@ -38,7 +38,7 @@ describe('InlineAlert', () => {
     it('renders info icon for info variant', () => {
       const { container } = render(<InlineAlert variant="info">Message</InlineAlert>);
       const icon = container.querySelector('svg');
-      expect(icon).toHaveClass('text-primary');
+      expect(icon).toHaveClass('text-info');
     });
 
     it('renders check icon for success variant', () => {

--- a/packages/component-library/src/components/atoms/InlineAlert/InlineAlert.tsx
+++ b/packages/component-library/src/components/atoms/InlineAlert/InlineAlert.tsx
@@ -9,7 +9,7 @@ const alertVariants = cva(
   {
     variants: {
       variant: {
-        info: 'bg-primary/10 border-primary/20 text-foreground',
+        info: 'bg-info/10 border-info/20 text-foreground',
         success: 'bg-success/10 border-success/20 text-foreground',
         warning: 'bg-warning/10 border-warning/20 text-foreground',
         error: 'bg-destructive/10 border-destructive/20 text-foreground',
@@ -24,7 +24,7 @@ const alertVariants = cva(
 const iconVariants = cva('h-4 w-4 shrink-0 mt-0.5', {
   variants: {
     variant: {
-      info: 'text-primary',
+      info: 'text-info',
       success: 'text-success',
       warning: 'text-warning',
       error: 'text-destructive',

--- a/packages/component-library/src/components/atoms/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
+++ b/packages/component-library/src/components/atoms/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`InlineAlert > snapshots > matches snapshot for dismissible alert 1`] = `
 <div
-  class="flex items-start gap-3 p-4 rounded-md border bg-primary/10 border-primary/20 text-foreground"
+  class="flex items-start gap-3 p-4 rounded-md border bg-info/10 border-info/20 text-foreground"
   role="alert"
 >
   <svg
     aria-hidden="true"
-    class="lucide lucide-info h-4 w-4 shrink-0 mt-0.5 text-primary"
+    class="lucide lucide-info h-4 w-4 shrink-0 mt-0.5 text-info"
     fill="none"
     height="24"
     stroke="currentColor"
@@ -66,12 +66,12 @@ exports[`InlineAlert > snapshots > matches snapshot for dismissible alert 1`] = 
 
 exports[`InlineAlert > snapshots > matches snapshot for info variant 1`] = `
 <div
-  class="flex items-start gap-3 p-4 rounded-md border bg-primary/10 border-primary/20 text-foreground"
+  class="flex items-start gap-3 p-4 rounded-md border bg-info/10 border-info/20 text-foreground"
   role="alert"
 >
   <svg
     aria-hidden="true"
-    class="lucide lucide-info h-4 w-4 shrink-0 mt-0.5 text-primary"
+    class="lucide lucide-info h-4 w-4 shrink-0 mt-0.5 text-info"
     fill="none"
     height="24"
     stroke="currentColor"

--- a/packages/component-library/src/styles/globals.css
+++ b/packages/component-library/src/styles/globals.css
@@ -24,6 +24,8 @@
     --color-success-foreground: 15 23 42;
     --color-warning: 245 158 11;
     --color-warning-foreground: 15 23 42;
+    --color-info: 59 130 246;
+    --color-info-foreground: 255 255 255;
     --color-border: 226 232 240;
     --color-input: 226 232 240;
     --color-ring: 79 70 229;
@@ -51,6 +53,8 @@
     --color-success-foreground: 15 15 25;
     --color-warning: 251 191 36;
     --color-warning-foreground: 15 15 25;
+    --color-info: 96 165 250;
+    --color-info-foreground: 15 15 25;
     --color-border: 40 40 65;
     --color-input: 40 40 65;
     --color-ring: 129 140 248;

--- a/packages/component-library/tailwind.config.ts
+++ b/packages/component-library/tailwind.config.ts
@@ -31,6 +31,10 @@ export default {
           DEFAULT: 'rgb(var(--color-warning) / <alpha-value>)',
           foreground: 'rgb(var(--color-warning-foreground) / <alpha-value>)',
         },
+        info: {
+          DEFAULT: 'rgb(var(--color-info) / <alpha-value>)',
+          foreground: 'rgb(var(--color-info-foreground) / <alpha-value>)',
+        },
         muted: {
           DEFAULT: 'rgb(var(--color-muted) / <alpha-value>)',
           foreground: 'rgb(var(--color-muted-foreground) / <alpha-value>)',


### PR DESCRIPTION
## Summary
- switch `InlineAlert` info variant from `primary` styling to semantic `info` styling
- add semantic `info` design token mappings in both component-library and app Tailwind/theme layers
- update InlineAlert tests and snapshots to match info styling

Closes #100

## Validation
- npm run test:watch --workspace=packages/component-library -- src/components/atoms/InlineAlert/InlineAlert.test.tsx -u
- npm run test:watch --workspace=packages/component-library -- src/components/organisms/ApiKeyConfiguration/ApiKeyConfiguration.test.tsx
- pre-commit checks (lint + unit tests + app lint/typecheck + FTA)
