### PR TITLE
feat: add prominent API key security messaging on config page

### DIFF
--- a/packages/app/public/locales/en/common.json
+++ b/packages/app/public/locales/en/common.json
@@ -122,6 +122,12 @@
       "apiKeysConfigured": "{{count}} API key configured.",
       "apiKeysConfigured_other": "{{count}} API keys configured.",
       "configureMoreOrContinue": "Configure more or continue selecting models.",
+      "securityNoticeTitle": "Your API keys stay secure in Free Mode",
+      "securityNoticeDescription": "Before you add a key, here is exactly how Free Mode protects your credentials:",
+      "securityNoticeBulletNeverLeavesBrowser": "API keys never leave your browser.",
+      "securityNoticeBulletAesEncryption": "Keys are encrypted locally with AES-256.",
+      "securityNoticeBulletNoServerStorage": "No keys are sent to or stored on Ensemble AI servers.",
+      "securityNoticeBulletDirectApiCalls": "API requests are sent directly from your browser to each provider.",
       "webCryptoUnsupportedTitle": "Browser not supported for Free Mode",
       "webCryptoUnsupportedDescription": "Free Mode requires the Web Crypto API to encrypt your API keys locally. Switch to a modern browser or use Pro Mode when it becomes available."
     },

--- a/packages/app/public/locales/fr/common.json
+++ b/packages/app/public/locales/fr/common.json
@@ -114,6 +114,12 @@
       "apiKeysConfigured": "{{count}} clé API configurée.",
       "apiKeysConfigured_other": "{{count}} clés API configurées.",
       "configureMoreOrContinue": "Configurez-en plus ou continuez à sélectionner des modèles.",
+      "securityNoticeTitle": "Vos clés API restent sécurisées en mode gratuit",
+      "securityNoticeDescription": "Avant d'ajouter une clé, voici précisément comment le mode gratuit protège vos identifiants :",
+      "securityNoticeBulletNeverLeavesBrowser": "Les clés API ne quittent jamais votre navigateur.",
+      "securityNoticeBulletAesEncryption": "Les clés sont chiffrées localement avec AES-256.",
+      "securityNoticeBulletNoServerStorage": "Aucune clé n'est envoyée ni stockée sur les serveurs d'Ensemble AI.",
+      "securityNoticeBulletDirectApiCalls": "Les requêtes API sont envoyées directement depuis votre navigateur vers chaque fournisseur.",
       "webCryptoUnsupportedTitle": "Navigateur incompatible avec le mode gratuit",
       "webCryptoUnsupportedDescription": "Le mode gratuit nécessite l'API Web Crypto pour chiffrer vos clés API localement. Utilisez un navigateur moderne ou passez au mode Pro lorsqu'il sera disponible."
     },

--- a/packages/app/src/app/config/page.tsx
+++ b/packages/app/src/app/config/page.tsx
@@ -64,7 +64,24 @@ export default function ConfigPage() {
       </div>
 
       {displayMode === 'free' && (
-        <div className="mt-8">
+        <div className="mt-8 space-y-6">
+          <InlineAlert variant="info">
+            <div>
+              <p className="text-base font-semibold">
+                {t('pages.config.securityNoticeTitle')}
+              </p>
+              <p className="mt-1">
+                {t('pages.config.securityNoticeDescription')}
+              </p>
+              <ul className="mt-3 list-disc space-y-1 pl-5">
+                <li>{t('pages.config.securityNoticeBulletNeverLeavesBrowser')}</li>
+                <li>{t('pages.config.securityNoticeBulletAesEncryption')}</li>
+                <li>{t('pages.config.securityNoticeBulletNoServerStorage')}</li>
+                <li>{t('pages.config.securityNoticeBulletDirectApiCalls')}</li>
+              </ul>
+            </div>
+          </InlineAlert>
+
           <ApiKeyConfiguration
             items={displayApiKeyItems}
             configuredCountOverride={configuredCountOverride}

--- a/packages/e2e/tests/mock-mode/config-page.spec.ts
+++ b/packages/e2e/tests/mock-mode/config-page.spec.ts
@@ -41,6 +41,24 @@ test.describe('Config Page', () => {
     await expect(page.getByTestId('workflow-navigator')).toBeVisible();
   });
 
+  test('shows prominent API key security messaging', async ({ page }) => {
+    await expect(
+      page.getByText(/your api keys stay secure in free mode/i)
+    ).toBeVisible();
+    await expect(
+      page.getByText(/api keys never leave your browser/i)
+    ).toBeVisible();
+    await expect(
+      page.getByText(/keys are encrypted locally with aes-256/i)
+    ).toBeVisible();
+    await expect(
+      page.getByText(/no keys are sent to or stored on ensemble ai servers/i)
+    ).toBeVisible();
+    await expect(
+      page.getByText(/api requests are sent directly from your browser to each provider/i)
+    ).toBeVisible();
+  });
+
   test('displays mode selection cards', async ({ page }) => {
     // Check for Free mode card
     await expect(page.locator('[data-mode="free"]')).toBeVisible();


### PR DESCRIPTION
## Summary
- add a prominent security callout on the `/config` page above API key inputs in Free Mode
- explicitly communicate all key trust guarantees: browser-only key handling, AES-256 local encryption, no server key storage, and direct browser-to-provider API calls
- add new i18n strings for this messaging in English and French
- add a focused mock-mode E2E assertion to ensure the security messaging remains visible

Closes #107

## Validation
- npm run lint --workspace=packages/app
- npm run typecheck --workspace=packages/app
- npm run test:mock --workspace=packages/e2e -- tests/mock-mode/config-page.spec.ts
- pre-commit checks (component-library lint/unit tests, shared-utils tests, app lint/typecheck, FTA)
