### PR TITLE
feat: remove upper bound on model selection (#102)

### DIFF
--- a/packages/app/public/locales/en/common.json
+++ b/packages/app/public/locales/en/common.json
@@ -127,7 +127,7 @@
     },
     "ensemble": {
       "title": "Build Your Ensemble",
-      "description": "Select 2-6 AI models to compare their responses"
+      "description": "Select at least 2 AI models to compare their responses"
     },
     "prompt": {
       "title": "Enter Your Prompt",

--- a/packages/app/public/locales/fr/common.json
+++ b/packages/app/public/locales/fr/common.json
@@ -119,7 +119,7 @@
     },
     "ensemble": {
       "title": "Construire votre ensemble",
-      "description": "Sélectionnez 2 à 6 modèles d'IA pour comparer leurs réponses"
+      "description": "Sélectionnez au moins 2 modèles d'IA pour comparer leurs réponses"
     },
     "prompt": {
       "title": "Entrez votre invite",

--- a/packages/app/src/app/ensemble/hooks/useEnsemblePage.ts
+++ b/packages/app/src/app/ensemble/hooks/useEnsemblePage.ts
@@ -132,10 +132,7 @@ export function useEnsemblePage() {
             // Remove using the selected model's unique ID
             removeModel(selectedModel.id);
         } else {
-            // Add model if under limit
-            if (selectedModels.length < 6) {
-                addModel(availableModel.provider, availableModel.id);
-            }
+            addModel(availableModel.provider, availableModel.id);
         }
     };
 
@@ -225,9 +222,9 @@ export function useEnsemblePage() {
         };
     });
 
-    // Continue button enabled if 2-6 models selected
+    // Continue button enabled if at least 2 models selected
     const isValid =
-        hasHydrated && selectedModels.length >= 2 && selectedModels.length <= 6;
+        hasHydrated && selectedModels.length >= 2;
 
     return {
         t,

--- a/packages/app/src/app/ensemble/page.tsx
+++ b/packages/app/src/app/ensemble/page.tsx
@@ -2,7 +2,7 @@
  * Ensemble Page (T158)
  *
  * Step 2 of the 4-step workflow: Model Selection
- * User selects 2-6 AI models and designates one as the summarizer
+ * User selects 2+ AI models and designates one as the summarizer
  */
 
 'use client';
@@ -58,7 +58,6 @@ export default function EnsemblePage() {
             models={availableModels}
             selectedModelIds={displayedSelectedModelIds}
             summarizerModelId={displayedSummarizer}
-            maxSelection={6}
             providerStatus={providerStatus}
             isMockMode={isMockMode}
             onModelToggle={handleModelToggle}

--- a/packages/e2e/tests/mock-mode/ensemble-page.spec.ts
+++ b/packages/e2e/tests/mock-mode/ensemble-page.spec.ts
@@ -3,7 +3,7 @@
  *
  * Tests the /ensemble page workflow:
  * - Page loads
- * - Model selection (min 2, max 6)
+ * - Model selection (min 2, no max)
  * - Summarizer designation
  * - Embeddings provider selection
  * - Navigation to /prompt after valid selection
@@ -77,7 +77,7 @@ test.describe('Ensemble Page', () => {
     await expect(nextButton).toBeEnabled();
   });
 
-  test('enforces maximum 6 models', async ({ page }) => {
+  test('does not enforce an upper model selection limit', async ({ page }) => {
     // Ensure enough providers are enabled
     await page.goto('/config');
     await page.locator('[data-mode="free"]').click();
@@ -89,13 +89,14 @@ test.describe('Ensemble Page', () => {
     const enabledCards = enabledModels(page);
     const count = await enabledCards.count();
 
-    for (let i = 0; i < Math.min(6, count); i++) {
+    for (let i = 0; i < Math.min(7, count); i++) {
       await enabledCards.nth(i).click();
     }
 
     const seventhEnabled = enabledCards.nth(6);
     if (await seventhEnabled.count()) {
-      await expect(seventhEnabled).toHaveAttribute('data-disabled', 'true');
+      await expect(seventhEnabled).toHaveAttribute('data-disabled', 'false');
+      await expect(seventhEnabled).toHaveAttribute('data-selected', 'true');
     }
   });
 


### PR DESCRIPTION
## Summary
- remove the ensemble model selection upper-bound enforcement in app state/validation
- update ensemble page copy from "2-6" to "at least 2" in English and French
- update mock-mode E2E coverage to assert no upper selection cap is enforced

## Validation
- npm --workspace @ai-ensemble/e2e run test:mock -- tests/mock-mode/ensemble-page.spec.ts

Closes #102