### PR TITLE
feat: implement MajorityVotingConsensus strategy (#108)

### DIFF
--- a/packages/shared-utils/src/consensus/MajorityVotingConsensus.ts
+++ b/packages/shared-utils/src/consensus/MajorityVotingConsensus.ts
@@ -1,0 +1,222 @@
+import type { AIProvider } from '../providers/types';
+import type {
+    ConsensusModelResponse,
+    ConsensusStrategy,
+    RankingResult,
+} from './types';
+
+interface MajorityVotingOutput {
+    rankings?: {
+        modelId?: string;
+        alignmentScore?: number;
+    }[];
+}
+
+const MIN_RESPONSES_FOR_MAJORITY = 2;
+
+export class MajorityVotingConsensus implements ConsensusStrategy {
+    constructor(
+        private summarizerProvider: AIProvider,
+        private summarizerModelId: string
+    ) { }
+
+    async rankResponses(
+        responses: ConsensusModelResponse[],
+        prompt: string
+    ): Promise<RankingResult[]> {
+        if (responses.length < MIN_RESPONSES_FOR_MAJORITY) {
+            throw new Error('At least 2 responses are required for majority voting');
+        }
+
+        const rankingPrompt = this.buildRankingPrompt(responses, prompt);
+
+        try {
+            const llmOutput = await this.completePrompt(rankingPrompt);
+            const parsed = this.parseMajorityVotingOutput(llmOutput, responses);
+            return parsed ?? this.buildFallbackRankings(responses);
+        } catch {
+            return this.buildFallbackRankings(responses);
+        }
+    }
+
+    async generateConsensus(
+        responses: ConsensusModelResponse[],
+        topN: number,
+        prompt: string
+    ): Promise<string> {
+        if (responses.length < MIN_RESPONSES_FOR_MAJORITY) {
+            throw new Error('At least 2 responses are required for majority voting');
+        }
+
+        const rankings = await this.rankResponses(responses, prompt);
+        const effectiveTopN = topN > 0
+            ? Math.min(topN, rankings.length)
+            : rankings.length;
+
+        const topModelIds = new Set(
+            rankings.slice(0, effectiveTopN).map((item) => item.modelId)
+        );
+
+        const selectedResponses = responses.filter((response) =>
+            topModelIds.has(response.modelId)
+        );
+
+        const rankedResponseText = selectedResponses
+            .map((response) => {
+                const result = rankings.find((item) => item.modelId === response.modelId);
+                const score = result?.eloScore ?? 0;
+
+                return `Model: ${response.modelName}\nModel ID: ${response.modelId}\nAlignment Score: ${score}\nResponse:\n${response.content}`;
+            })
+            .join('\n\n---\n\n');
+
+        const majorityModel = rankings[0]?.modelId ?? selectedResponses[0]?.modelId;
+
+        const synthesisPrompt = `
+You are a helpful assistant tasked with creating a final consensus answer from multiple model outputs.
+Original Question: ${prompt}
+
+Majority Signal:
+- Treat the model with ID "${majorityModel}" as the majority anchor.
+- Prefer details repeated across multiple responses.
+- De-prioritize claims that appear in only one response unless they are clearly more correct or complete.
+
+Ranked model responses:
+${rankedResponseText}
+
+Return a SINGLE final answer that directly addresses the original question.
+Do not mention model names, ranking, or voting. Write only the final answer text.
+        `.trim();
+
+        try {
+            return await this.completePrompt(synthesisPrompt);
+        } catch {
+            return 'Failed to generate summary.';
+        }
+    }
+
+    private buildRankingPrompt(
+        responses: ConsensusModelResponse[],
+        originalPrompt: string
+    ): string {
+        const responseText = responses
+            .map(
+                (response) =>
+                    `Model ID: ${response.modelId}\nModel Name: ${response.modelName}\nResponse:\n${response.content}`
+            )
+            .join('\n\n---\n\n');
+
+        return `
+You are evaluating multiple AI responses for majority alignment.
+Original Question: ${originalPrompt}
+
+Responses:
+${responseText}
+
+Task:
+1) Identify which response best represents the majority position.
+2) Rank all responses by alignment with that majority position.
+3) Output ONLY valid JSON in this shape:
+{
+  "rankings": [
+    { "modelId": "exact-model-id", "alignmentScore": 0-100 }
+  ]
+}
+
+Rules:
+- Include every model exactly once.
+- Higher alignmentScore means stronger alignment with majority position.
+- No prose, no markdown, JSON only.
+        `.trim();
+    }
+
+    private completePrompt(prompt: string): Promise<string> {
+        return new Promise((resolve, reject) => {
+            this.summarizerProvider.streamResponse(
+                prompt,
+                this.summarizerModelId,
+                () => { void 0; },
+                (finalText: string) => resolve(finalText),
+                (err: Error) => reject(err)
+            );
+        });
+    }
+
+    private parseMajorityVotingOutput(
+        output: string,
+        responses: ConsensusModelResponse[]
+    ): RankingResult[] | null {
+        const parsed = this.tryParseJson(output);
+        if (!parsed) {
+            return null;
+        }
+
+        const responseIds = new Set(responses.map((response) => response.modelId));
+        const rankings: RankingResult[] = [];
+        const seenIds = new Set<string>();
+
+        for (const item of parsed.rankings ?? []) {
+            if (!item?.modelId || !responseIds.has(item.modelId) || seenIds.has(item.modelId)) {
+                continue;
+            }
+
+            const score = typeof item.alignmentScore === 'number'
+                ? Math.max(0, Math.min(100, item.alignmentScore))
+                : 0;
+
+            rankings.push({
+                modelId: item.modelId,
+                eloScore: score,
+                rank: 0,
+            });
+
+            seenIds.add(item.modelId);
+        }
+
+        if (rankings.length === 0) {
+            return null;
+        }
+
+        for (const response of responses) {
+            if (!seenIds.has(response.modelId)) {
+                rankings.push({
+                    modelId: response.modelId,
+                    eloScore: 0,
+                    rank: 0,
+                });
+            }
+        }
+
+        rankings.sort((a, b) => b.eloScore - a.eloScore);
+        rankings.forEach((item, index) => {
+            item.rank = index + 1;
+        });
+
+        return rankings;
+    }
+
+    private tryParseJson(output: string): MajorityVotingOutput | null {
+        try {
+            return JSON.parse(output) as MajorityVotingOutput;
+        } catch {
+            const fencedMatch = output.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+            if (!fencedMatch?.[1]) {
+                return null;
+            }
+
+            try {
+                return JSON.parse(fencedMatch[1]) as MajorityVotingOutput;
+            } catch {
+                return null;
+            }
+        }
+    }
+
+    private buildFallbackRankings(responses: ConsensusModelResponse[]): RankingResult[] {
+        return responses.map((response, index) => ({
+            modelId: response.modelId,
+            eloScore: 0,
+            rank: index + 1,
+        }));
+    }
+}

--- a/packages/shared-utils/src/consensus/__tests__/MajorityVotingConsensus.test.ts
+++ b/packages/shared-utils/src/consensus/__tests__/MajorityVotingConsensus.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { MajorityVotingConsensus } from '../MajorityVotingConsensus';
+import type { AIProvider } from '../../../providers/types';
+import type { ConsensusModelResponse } from '../types';
+
+describe('MajorityVotingConsensus', () => {
+    let mockSummarizerProvider: AIProvider;
+    let strategy: MajorityVotingConsensus;
+
+    const mockResponses: ConsensusModelResponse[] = [
+        { modelId: 'model-a', modelName: 'Model A', content: 'Response A content' },
+        { modelId: 'model-b', modelName: 'Model B', content: 'Response B content' },
+        { modelId: 'model-c', modelName: 'Model C', content: 'Response C content' },
+    ];
+
+    beforeEach(() => {
+        mockSummarizerProvider = {
+            streamResponse: vi.fn(),
+            generateEmbeddings: vi.fn(),
+            validateApiKey: vi.fn(),
+            listAvailableModels: vi.fn(),
+            listAvailableTextModels: vi.fn(),
+        } as unknown as AIProvider;
+
+        strategy = new MajorityVotingConsensus(
+            mockSummarizerProvider,
+            'summarizer-model-id'
+        );
+    });
+
+    it('should throw error if fewer than 2 responses are provided', async () => {
+        const minimalResponses = mockResponses.slice(0, 1);
+        await expect(
+            strategy.rankResponses(minimalResponses, 'Test Prompt')
+        ).rejects.toThrow('At least 2 responses are required for majority voting');
+    });
+
+    it('should rank responses based on majority alignment', async () => {
+        (mockSummarizerProvider.streamResponse as Mock).mockImplementation(async (
+            _prompt: string,
+            _model: string,
+            _onChunk: (chunk: string) => void,
+            onComplete: (full: string, time: number, tokens?: number) => void
+        ) => {
+            onComplete(JSON.stringify({
+                rankings: [
+                    { modelId: 'model-b', alignmentScore: 95 },
+                    { modelId: 'model-a', alignmentScore: 88 },
+                    { modelId: 'model-c', alignmentScore: 74 },
+                ],
+            }), 100, 10);
+            return Promise.resolve();
+        });
+
+        const ranking = await strategy.rankResponses(mockResponses, 'Test Prompt');
+
+        expect(ranking).toHaveLength(3);
+        expect(ranking[0]).toMatchObject({ modelId: 'model-b', rank: 1, eloScore: 95 });
+        expect(ranking[1]).toMatchObject({ modelId: 'model-a', rank: 2, eloScore: 88 });
+        expect(ranking[2]).toMatchObject({ modelId: 'model-c', rank: 3, eloScore: 74 });
+    });
+
+    it('should generate consensus using top N ranked responses', async () => {
+        vi.spyOn(strategy, 'rankResponses').mockResolvedValue([
+            { modelId: 'model-b', eloScore: 96, rank: 1 },
+            { modelId: 'model-a', eloScore: 90, rank: 2 },
+            { modelId: 'model-c', eloScore: 65, rank: 3 },
+        ]);
+
+        (mockSummarizerProvider.streamResponse as Mock).mockImplementation(async (
+            _prompt: string,
+            _model: string,
+            _onChunk: (chunk: string) => void,
+            onComplete: (full: string, time: number, tokens?: number) => void
+        ) => {
+            onComplete('Majority Consensus Summary', 100, 10);
+            return Promise.resolve();
+        });
+
+        const summary = await strategy.generateConsensus(mockResponses, 2, 'Original Prompt');
+
+        expect(summary).toBe('Majority Consensus Summary');
+        expect(strategy.rankResponses).toHaveBeenCalledWith(mockResponses, 'Original Prompt');
+
+        const calls = (mockSummarizerProvider.streamResponse as Mock).mock.calls;
+        const promptArg = calls[0][0];
+
+        expect(promptArg).toContain('Model B');
+        expect(promptArg).toContain('Model A');
+        expect(promptArg).not.toContain('Model C');
+    });
+
+    it('should fall back to deterministic ranking when ranking JSON is invalid', async () => {
+        (mockSummarizerProvider.streamResponse as Mock).mockImplementation(async (
+            _prompt: string,
+            _model: string,
+            _onChunk: (chunk: string) => void,
+            onComplete: (full: string, time: number, tokens?: number) => void
+        ) => {
+            onComplete('not valid json', 100, 10);
+            return Promise.resolve();
+        });
+
+        const ranking = await strategy.rankResponses(mockResponses, 'Test Prompt');
+        expect(ranking).toEqual([
+            { modelId: 'model-a', eloScore: 0, rank: 1 },
+            { modelId: 'model-b', eloScore: 0, rank: 2 },
+            { modelId: 'model-c', eloScore: 0, rank: 3 },
+        ]);
+    });
+});

--- a/packages/shared-utils/src/consensus/index.ts
+++ b/packages/shared-utils/src/consensus/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './StandardConsensus';
 export * from './EloRankingConsensus';
+export * from './MajorityVotingConsensus';


### PR DESCRIPTION
## Summary
- add new `MajorityVotingConsensus` strategy in shared utils
- implement majority-alignment ranking for 2+ responses via summarizer provider
- implement consensus synthesis weighted toward majority-ranked responses
- export the new strategy from consensus index
- add unit tests for ranking, top-N synthesis path, validation, and JSON fallback behavior

## Validation
- npm run lint --workspace @ensemble-ai/shared-utils
- npm run test --workspace @ensemble-ai/shared-utils
- npm run typecheck --workspace @ensemble-ai/shared-utils
- npm run build --workspace @ensemble-ai/shared-utils

Closes #108
