### PR TITLE
fix: make header brand name clickable and link to home

### DIFF
--- a/packages/component-library/src/components/molecules/EnsembleHeader/EnsembleHeader.test.tsx
+++ b/packages/component-library/src/components/molecules/EnsembleHeader/EnsembleHeader.test.tsx
@@ -14,6 +14,13 @@ describe('EnsembleHeader', () => {
     expect(screen.getByText('The smartest AI is an ensemble.')).toBeInTheDocument();
   });
 
+  it('renders the brand name as a link to /config', () => {
+    render(<EnsembleHeader />);
+    const brandLink = screen.getByRole('link', { name: /ensemble ai/i });
+    expect(brandLink).toBeInTheDocument();
+    expect(brandLink).toHaveAttribute('href', '/config');
+  });
+
   it('renders the settings button', () => {
     render(<EnsembleHeader />);
     const settingsButton = screen.getByRole('button', { name: /open settings/i });

--- a/packages/component-library/src/components/molecules/EnsembleHeader/EnsembleHeader.tsx
+++ b/packages/component-library/src/components/molecules/EnsembleHeader/EnsembleHeader.tsx
@@ -22,10 +22,10 @@ export function EnsembleHeader({ onSettingsClick }: EnsembleHeaderProps) {
     <div className="bg-background border-b border-border">
       <div className="max-w-6xl mx-auto px-6 py-6">
         <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-bold text-foreground">{title}</h1>
+          <a href="/config" className="group block">
+            <h1 className="text-2xl font-bold text-foreground group-hover:text-primary transition-colors">{title}</h1>
             <p className="text-muted-foreground mt-1">{tagline}</p>
-          </div>
+          </a>
           <div className="flex items-center gap-4">
             <a
               href="/features"

--- a/packages/component-library/src/components/molecules/EnsembleHeader/__snapshots__/EnsembleHeader.snapshot.test.tsx.snap
+++ b/packages/component-library/src/components/molecules/EnsembleHeader/__snapshots__/EnsembleHeader.snapshot.test.tsx.snap
@@ -10,9 +10,12 @@ exports[`EnsembleHeader Snapshots > matches snapshot for default header 1`] = `
     <div
       class="flex items-center justify-between"
     >
-      <div>
+      <a
+        class="group block"
+        href="/config"
+      >
         <h1
-          class="text-2xl font-bold text-foreground"
+          class="text-2xl font-bold text-foreground group-hover:text-primary transition-colors"
         >
           Ensemble AI
         </h1>
@@ -21,7 +24,7 @@ exports[`EnsembleHeader Snapshots > matches snapshot for default header 1`] = `
         >
           The smartest AI is an ensemble.
         </p>
-      </div>
+      </a>
       <div
         class="flex items-center gap-4"
       >

--- a/packages/component-library/src/components/molecules/EnsembleHeader/__snapshots__/EnsembleHeader.test.tsx.snap
+++ b/packages/component-library/src/components/molecules/EnsembleHeader/__snapshots__/EnsembleHeader.test.tsx.snap
@@ -10,9 +10,12 @@ exports[`EnsembleHeader > snapshots > matches snapshot for default render 1`] = 
     <div
       class="flex items-center justify-between"
     >
-      <div>
+      <a
+        class="group block"
+        href="/config"
+      >
         <h1
-          class="text-2xl font-bold text-foreground"
+          class="text-2xl font-bold text-foreground group-hover:text-primary transition-colors"
         >
           Ensemble AI
         </h1>
@@ -21,7 +24,7 @@ exports[`EnsembleHeader > snapshots > matches snapshot for default render 1`] = 
         >
           The smartest AI is an ensemble.
         </p>
-      </div>
+      </a>
       <div
         class="flex items-center gap-4"
       >


### PR DESCRIPTION
## Summary
- Wrap "Ensemble AI" brand name in header with `<a href="/config">` so users can navigate back to the workflow start from any page
- Add `group-hover:text-primary` transition for visual feedback on hover
- Add unit test verifying the brand link points to `/config`
- Update snapshots

Closes #127

## Test plan
- [x] Component library lint passes
- [x] All 15 EnsembleHeader tests pass (including new brand link test)
- [x] App lint + typecheck pass
- [x] Production build succeeds
- [ ] All CI checks pass
- [ ] Visual: clicking brand name navigates to /config from Features/About pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)