### PR TITLE
fix: standardise prompt page container width to max-w-6xl

### DIFF
--- a/packages/app/src/app/prompt/page.tsx
+++ b/packages/app/src/app/prompt/page.tsx
@@ -149,7 +149,7 @@ export default function PromptPage() {
   const modelNames = selectedModelIds;
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-4xl">
+    <div className="container mx-auto px-4 py-8 max-w-6xl">
       <ProgressSteps currentStep={currentStep} fallbackStep="prompt" />
 
       <PageHero


### PR DESCRIPTION
## Summary
- Change prompt page from `max-w-4xl` to `max-w-6xl` to match config, ensemble, and review pages
- Eliminates the jarring width shift between workflow steps 2→3→4

Closes #133

## Test plan
- [x] Lint + typecheck pass
- [x] Build succeeds
- [ ] All CI checks pass
- [ ] Visual: prompt page width now matches other workflow pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)