### PR TITLE
fix: use semantic header and nav elements in EnsembleHeader

### DIFF
--- a/packages/component-library/src/components/molecules/EnsembleHeader/EnsembleHeader.test.tsx
+++ b/packages/component-library/src/components/molecules/EnsembleHeader/EnsembleHeader.test.tsx
@@ -41,6 +41,17 @@ describe('EnsembleHeader', () => {
     expect(featuresLink).toHaveAttribute('href', '/features');
   });
 
+  it('uses semantic header element', () => {
+    const { container } = render(<EnsembleHeader />);
+    expect(container.firstChild?.nodeName).toBe('HEADER');
+  });
+
+  it('wraps navigation links in a nav element', () => {
+    render(<EnsembleHeader />);
+    const nav = screen.getByRole('navigation', { name: /main navigation/i });
+    expect(nav).toBeInTheDocument();
+  });
+
   it('applies correct styling classes', () => {
     const { container } = render(<EnsembleHeader />);
     const header = container.firstChild;

--- a/packages/component-library/src/components/molecules/EnsembleHeader/EnsembleHeader.tsx
+++ b/packages/component-library/src/components/molecules/EnsembleHeader/EnsembleHeader.tsx
@@ -19,14 +19,14 @@ export function EnsembleHeader({ onSettingsClick }: EnsembleHeaderProps) {
   const featuresLabel = isReady ? t('ensemble.header.features') : 'Features';
 
   return (
-    <div className="bg-background border-b border-border">
+    <header className="bg-background border-b border-border">
       <div className="max-w-6xl mx-auto px-6 py-6">
         <div className="flex items-center justify-between">
           <a href="/config" className="group block">
             <h1 className="text-2xl font-bold text-foreground group-hover:text-primary transition-colors">{title}</h1>
             <p className="text-muted-foreground mt-1">{tagline}</p>
           </a>
-          <div className="flex items-center gap-4">
+          <nav className="flex items-center gap-4" aria-label="Main navigation">
             <a
               href="/features"
               className="text-sm text-muted-foreground hover:text-foreground transition-colors"
@@ -46,9 +46,9 @@ export function EnsembleHeader({ onSettingsClick }: EnsembleHeaderProps) {
             >
               <Settings className="w-5 h-5 text-muted-foreground" />
             </button>
-          </div>
+          </nav>
         </div>
       </div>
-    </div>
+    </header>
   );
 }

--- a/packages/component-library/src/components/molecules/EnsembleHeader/__snapshots__/EnsembleHeader.snapshot.test.tsx.snap
+++ b/packages/component-library/src/components/molecules/EnsembleHeader/__snapshots__/EnsembleHeader.snapshot.test.tsx.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`EnsembleHeader Snapshots > matches snapshot for default header 1`] = `
-<div
+<header
   class="bg-background border-b border-border"
 >
   <div
@@ -25,7 +25,8 @@ exports[`EnsembleHeader Snapshots > matches snapshot for default header 1`] = `
           The smartest AI is an ensemble.
         </p>
       </a>
-      <div
+      <nav
+        aria-label="Main navigation"
         class="flex items-center gap-4"
       >
         <a
@@ -67,8 +68,8 @@ exports[`EnsembleHeader Snapshots > matches snapshot for default header 1`] = `
             />
           </svg>
         </button>
-      </div>
+      </nav>
     </div>
   </div>
-</div>
+</header>
 `;

--- a/packages/component-library/src/components/molecules/EnsembleHeader/__snapshots__/EnsembleHeader.test.tsx.snap
+++ b/packages/component-library/src/components/molecules/EnsembleHeader/__snapshots__/EnsembleHeader.test.tsx.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`EnsembleHeader > snapshots > matches snapshot for default render 1`] = `
-<div
+<header
   class="bg-background border-b border-border"
 >
   <div
@@ -25,7 +25,8 @@ exports[`EnsembleHeader > snapshots > matches snapshot for default render 1`] = 
           The smartest AI is an ensemble.
         </p>
       </a>
-      <div
+      <nav
+        aria-label="Main navigation"
         class="flex items-center gap-4"
       >
         <a
@@ -67,8 +68,8 @@ exports[`EnsembleHeader > snapshots > matches snapshot for default render 1`] = 
             />
           </svg>
         </button>
-      </div>
+      </nav>
     </div>
   </div>
-</div>
+</header>
 `;


### PR DESCRIPTION
## Summary
- Replace outer `<div>` with `<header>` element
- Wrap navigation links in `<nav aria-label="Main navigation">`
- Improves accessibility for screen readers and SEO
- Add unit tests for semantic element assertions

Closes #149

## Test plan
- [x] All 17 EnsembleHeader tests pass
- [x] Pre-commit hooks pass
- [ ] All CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)