### PR TITLE
fix: replace 'military-grade' with specific AES-256-GCM language

### DIFF
--- a/packages/app/public/locales/en/common.json
+++ b/packages/app/public/locales/en/common.json
@@ -292,7 +292,7 @@
       },
       "security": {
         "heading": "Security & Privacy",
-        "body": "Military-grade encryption with zero server-side storage in Free Mode.",
+        "body": "AES-256-GCM encryption with zero server-side storage in Free Mode.",
         "features": [
           "AES-256-GCM encryption via Web Crypto API",
           "Device-specific key derivation (SHA-256)",

--- a/packages/app/public/locales/fr/common.json
+++ b/packages/app/public/locales/fr/common.json
@@ -284,7 +284,7 @@
       },
       "security": {
         "heading": "Sécurité et confidentialité",
-        "body": "Chiffrement de niveau militaire sans stockage côté serveur en Mode Gratuit.",
+        "body": "Chiffrement AES-256-GCM sans stockage côté serveur en Mode Gratuit.",
         "features": [
           "Chiffrement AES-256-GCM via l'API Web Crypto",
           "Dérivation de clé spécifique à l'appareil (SHA-256)",


### PR DESCRIPTION
## Summary
- Replace "Military-grade encryption" with "AES-256-GCM encryption" in Features page security section
- Updated in both EN and FR locales
- More credible and specific for technical users

Closes #140

## Test plan
- [x] Pre-commit hooks pass
- [ ] All CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)