### PR TITLE
fix: reorder Prompt page — prompt input above config summary (#131)

### DIFF
--- a/packages/app/src/app/prompt/page.tsx
+++ b/packages/app/src/app/prompt/page.tsx
@@ -158,7 +158,16 @@ export default function PromptPage() {
       />
 
       <div className="mt-8 space-y-8">
-        {/* Ensemble Configuration Summary */}
+        {/* Prompt Input (primary action — immediately visible) */}
+        <PromptInputWithHint
+          value={localPrompt}
+          onChange={handlePromptChange}
+        />
+
+        {/* Tips for better prompts */}
+        <PromptTips />
+
+        {/* Ensemble Configuration Summary (secondary info) */}
         {selectedModelIds.length > 0 && (
           <EnsembleConfigurationSummary
             selectedModels={modelNames}
@@ -192,15 +201,6 @@ export default function PromptPage() {
             </div>
           </div>
         )}
-
-        {/* Prompt Input */}
-        <PromptInputWithHint
-          value={localPrompt}
-          onChange={handlePromptChange}
-        />
-
-        {/* Tips for better prompts */}
-        <PromptTips />
       </div>
 
       <div className="mt-12">


### PR DESCRIPTION
## Summary
- Move prompt input and tips above the ensemble configuration summary
- Primary action (entering the prompt) is now immediately visible without scrolling
- Configuration summary and manual responses moved below as secondary info

Closes #131

## Test plan
- [ ] All CI checks pass
- [ ] Prompt input is visible above the fold on the Prompt page

🤖 Generated with [Claude Code](https://claude.com/claude-code)