### PR TITLE
feat(eval): implement ensemble and benchmark runners

### DIFF
--- a/packages/eval/src/commands/baseline.ts
+++ b/packages/eval/src/commands/baseline.ts
@@ -6,7 +6,8 @@ import { createEvaluatorForDataset } from '../lib/evaluators.js';
 import { writeJsonFile } from '../lib/io.js';
 import { parseModelSpec } from '../lib/modelSpecs.js';
 import { registerProviders } from '../lib/providers.js';
-import { runPromptWithModels } from '../lib/runPrompt.js';
+import { EnsembleRunner } from '../lib/ensembleRunner.js';
+import { buildSelfConsistencyResult } from '../lib/selfConsistency.js';
 import type { BaselineResultsFile, EvalMode, PromptRunResult } from '../types.js';
 
 interface BaselineCommandOptions {
@@ -14,6 +15,8 @@ interface BaselineCommandOptions {
   samples: string;
   output: string;
   mode: EvalMode;
+  requestDelayMs?: string;
+  selfConsistencyRuns?: string;
 }
 
 export function createBaselineCommand(): Command {
@@ -27,12 +30,35 @@ export function createBaselineCommand(): Command {
     .requiredOption('--model <model>', 'Model spec in provider:model format.')
     .option('--samples <count>', 'Number of prompts to evaluate.', '10')
     .option('--output <file>', 'Output JSON file path.', 'eval-baseline-results.json')
+    .option(
+      '--self-consistency-runs <count>',
+      'Run the same model multiple times and record majority-vote self-consistency.',
+      '1',
+    )
+    .option(
+      '--request-delay-ms <ms>',
+      'Optional delay in milliseconds between starting model calls.',
+      '0',
+    )
     .option('--mode <mode>', 'Provider mode to use (mock or free)', 'mock')
     .action(async (dataset: string, options: BaselineCommandOptions) => {
       const modelSpec = parseModelSpec(options.model);
       const sampleCount = Number.parseInt(options.samples, 10);
       if (!Number.isInteger(sampleCount) || sampleCount <= 0) {
         throw new Error(`Invalid sample count "${options.samples}".`);
+      }
+      const selfConsistencyRuns = Number.parseInt(
+        options.selfConsistencyRuns ?? '1',
+        10,
+      );
+      if (!Number.isInteger(selfConsistencyRuns) || selfConsistencyRuns <= 0) {
+        throw new Error(
+          `Invalid self-consistency run count "${options.selfConsistencyRuns}".`,
+        );
+      }
+      const requestDelayMs = Number.parseInt(options.requestDelayMs ?? '0', 10);
+      if (!Number.isInteger(requestDelayMs) || requestDelayMs < 0) {
+        throw new Error(`Invalid request delay "${options.requestDelayMs}".`);
       }
 
       const { datasetName, questions } = await loadBenchmarkQuestions(dataset, {
@@ -42,14 +68,19 @@ export function createBaselineCommand(): Command {
 
       const registry = new ProviderRegistry();
       registerProviders(registry, [modelSpec.provider], options.mode);
+      const ensembleRunner = new EnsembleRunner(registry, options.mode, {
+        requestDelayMs,
+      });
 
       const runs: PromptRunResult[] = [];
+      const repeatedModelSpecs = Array.from(
+        { length: selfConsistencyRuns },
+        () => modelSpec,
+      );
       for (const question of questions) {
-        const responses = await runPromptWithModels(
-          registry,
-          options.mode,
+        const responses = await ensembleRunner.runPrompt(
           question.prompt,
-          [modelSpec],
+          repeatedModelSpecs,
         );
 
         const evaluation = await evaluateResponses(
@@ -66,6 +97,11 @@ export function createBaselineCommand(): Command {
           responses,
           consensus: {},
           evaluation,
+          selfConsistency: buildSelfConsistencyResult({
+            runCount: selfConsistencyRuns,
+            responses,
+            evaluation,
+          }),
         });
       }
 

--- a/packages/eval/src/index.ts
+++ b/packages/eval/src/index.ts
@@ -5,3 +5,6 @@ export * from './lib/evaluators.js';
 export * from './lib/parsers.js';
 export * from './lib/modelSpecs.js';
 export * from './lib/report.js';
+export * from './lib/ensembleRunner.js';
+export * from './lib/benchmarkRunner.js';
+export * from './lib/selfConsistency.js';

--- a/packages/eval/src/lib/benchmarkRunner.test.ts
+++ b/packages/eval/src/lib/benchmarkRunner.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type {
+  AIProvider,
+  ProviderRegistry,
+} from '@ensemble-ai/shared-utils/providers';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createBenchmarkFile } from '../commands/benchmarkOutput.js';
+import { BenchmarkRunner } from './benchmarkRunner.js';
+
+function buildProvider(): AIProvider {
+  return {
+    streamResponse: async (prompt, _model, _onChunk, onComplete) => {
+      onComplete(`echo:${prompt}`, 10, 100);
+    },
+    generateEmbeddings: async () => [],
+    validateApiKey: async () => ({ valid: true }),
+    listAvailableModels: () => [
+      {
+        id: 'gpt-4o',
+        name: 'gpt-4o',
+        provider: 'openai',
+        contextWindow: 128_000,
+        costPer1kTokens: 0.01,
+      },
+    ],
+    listAvailableTextModels: async () => ['gpt-4o'],
+  };
+}
+
+function buildRegistry(provider: AIProvider): ProviderRegistry {
+  return {
+    getProvider: () => provider,
+  } as unknown as ProviderRegistry;
+}
+
+describe('BenchmarkRunner', () => {
+  let scratchDir = '';
+
+  afterEach(async () => {
+    if (scratchDir) {
+      await rm(scratchDir, { recursive: true, force: true });
+    }
+  });
+
+  it('supports resume-style skipping and persists checkpoint updates', async () => {
+    scratchDir = await mkdtemp(join(tmpdir(), 'ensemble-benchmark-runner-'));
+    const outputPath = join(scratchDir, 'benchmark.json');
+    const output = createBenchmarkFile(
+      'gsm8k',
+      'mock',
+      ['openai:gpt-4o'],
+      ['standard'],
+      2,
+    );
+    output.runs.push({
+      questionId: 'q1',
+      prompt: 'Question 1',
+      groundTruth: 'echo:Question 1',
+      responses: [],
+      consensus: {},
+    });
+
+    const events: Array<{ questionId: string; skipped: boolean }> = [];
+    const runner = new BenchmarkRunner({
+      mode: 'mock',
+      registry: buildRegistry(buildProvider()),
+      models: [{ provider: 'openai', model: 'gpt-4o' }],
+      strategies: ['standard'],
+      evaluator: {
+        name: 'generative',
+        evaluate: async (response, groundTruth) => ({
+          correct: response === groundTruth,
+          predicted: response,
+          expected: groundTruth,
+        }),
+      },
+      summarizer: { provider: 'openai', model: 'gpt-4o' },
+    });
+
+    await runner.run({
+      questions: [
+        { id: 'q1', prompt: 'Question 1', groundTruth: 'echo:Question 1' },
+        { id: 'q2', prompt: 'Question 2', groundTruth: 'echo:Question 2' },
+      ],
+      output,
+      outputPath,
+      onProgress: (progress) => {
+        events.push({ questionId: progress.questionId, skipped: progress.skipped });
+      },
+    });
+
+    expect(events).toEqual([
+      { questionId: 'q1', skipped: true },
+      { questionId: 'q2', skipped: false },
+    ]);
+    expect(output.runs).toHaveLength(2);
+    expect(output.runs[1]).toMatchObject({
+      questionId: 'q2',
+      prompt: 'Question 2',
+    });
+
+    const persisted = JSON.parse(await readFile(outputPath, 'utf-8')) as {
+      runs: Array<{ questionId: string }>;
+    };
+    expect(persisted.runs).toHaveLength(2);
+    expect(persisted.runs[1].questionId).toBe('q2');
+  });
+});

--- a/packages/eval/src/lib/benchmarkRunner.ts
+++ b/packages/eval/src/lib/benchmarkRunner.ts
@@ -1,0 +1,134 @@
+import type { ProviderRegistry } from '@ensemble-ai/shared-utils/providers';
+import { generateConsensus } from './consensus.js';
+import { evaluateResponses, type EvaluatorLike } from './evaluation.js';
+import { writeJsonFile } from './io.js';
+import { EnsembleRunner } from './ensembleRunner.js';
+import type {
+  BenchmarkQuestion,
+  BenchmarkResultsFile,
+  EvalMode,
+  ModelSpec,
+  PromptRunResult,
+  StrategyName,
+} from '../types.js';
+
+export interface BenchmarkRunnerProgress {
+  completed: number;
+  total: number;
+  questionId: string;
+  skipped: boolean;
+}
+
+interface BenchmarkRunnerConfig {
+  mode: EvalMode;
+  registry: ProviderRegistry;
+  models: ModelSpec[];
+  strategies: StrategyName[];
+  evaluator: EvaluatorLike | null;
+  summarizer: ModelSpec | null;
+  requestDelayMs?: number;
+}
+
+interface RunBenchmarkOptions {
+  questions: BenchmarkQuestion[];
+  outputPath: string;
+  output: BenchmarkResultsFile;
+  onProgress?: (progress: BenchmarkRunnerProgress) => void;
+}
+
+export class BenchmarkRunner {
+  private readonly mode: EvalMode;
+  private readonly registry: ProviderRegistry;
+  private readonly models: ModelSpec[];
+  private readonly strategies: StrategyName[];
+  private readonly evaluator: EvaluatorLike | null;
+  private readonly summarizer: ModelSpec | null;
+  private readonly ensembleRunner: EnsembleRunner;
+
+  constructor(config: BenchmarkRunnerConfig) {
+    this.mode = config.mode;
+    this.registry = config.registry;
+    this.models = config.models;
+    this.strategies = config.strategies;
+    this.evaluator = config.evaluator;
+    this.summarizer = config.summarizer;
+    this.ensembleRunner = new EnsembleRunner(config.registry, config.mode, {
+      requestDelayMs: config.requestDelayMs,
+    });
+  }
+
+  async run(options: RunBenchmarkOptions): Promise<BenchmarkResultsFile> {
+    const { questions, outputPath, output, onProgress } = options;
+    const completedQuestionIds = new Set(
+      output.runs
+        .map((run) => run.questionId)
+        .filter((questionId): questionId is string => Boolean(questionId)),
+    );
+    const completedPrompts = new Set(output.runs.map((run) => run.prompt));
+
+    for (const [index, question] of questions.entries()) {
+      const alreadyCompleted =
+        completedQuestionIds.has(question.id) || completedPrompts.has(question.prompt);
+      if (alreadyCompleted) {
+        onProgress?.({
+          completed: index + 1,
+          total: questions.length,
+          questionId: question.id,
+          skipped: true,
+        });
+        continue;
+      }
+
+      const responses = await this.ensembleRunner.runPrompt(
+        question.prompt,
+        this.models,
+      );
+
+      const firstSuccessful = responses.find((response) => !response.error);
+      const summarizerTarget = this.summarizer
+        ? this.summarizer
+        : firstSuccessful
+          ? { provider: firstSuccessful.provider, model: firstSuccessful.model }
+          : null;
+      const consensus = summarizerTarget
+        ? await generateConsensus(
+            this.strategies,
+            question.prompt,
+            responses,
+            this.registry.getProvider(summarizerTarget.provider, this.mode),
+            summarizerTarget.model,
+          )
+        : {};
+
+      const evaluation = await evaluateResponses(
+        this.evaluator,
+        responses,
+        question.groundTruth,
+        question.prompt,
+      );
+
+      const run: PromptRunResult = {
+        questionId: question.id,
+        prompt: question.prompt,
+        groundTruth: question.groundTruth,
+        responses,
+        consensus,
+        evaluation,
+      };
+      output.runs.push(run);
+      output.updatedAt = new Date().toISOString();
+      completedQuestionIds.add(question.id);
+      completedPrompts.add(question.prompt);
+      await writeJsonFile(outputPath, output);
+
+      onProgress?.({
+        completed: index + 1,
+        total: questions.length,
+        questionId: question.id,
+        skipped: false,
+      });
+    }
+
+    return output;
+  }
+}

--- a/packages/eval/src/lib/consensus.test.ts
+++ b/packages/eval/src/lib/consensus.test.ts
@@ -1,0 +1,77 @@
+import type { AIProvider } from '@ensemble-ai/shared-utils/providers';
+import { describe, expect, it } from 'vitest';
+import { generateConsensus, parseStrategies } from './consensus.js';
+import type { ProviderResponse } from '../types.js';
+
+function buildProvider(onStream: AIProvider['streamResponse']): AIProvider {
+  return {
+    streamResponse: onStream,
+    generateEmbeddings: async () => [],
+    validateApiKey: async () => ({ valid: true }),
+    listAvailableModels: () => [],
+    listAvailableTextModels: async () => [],
+  };
+}
+
+describe('consensus', () => {
+  it('parses majority strategy and rejects unknown strategy values', () => {
+    expect(parseStrategies(['standard,majority', 'elo'])).toEqual([
+      'standard',
+      'majority',
+      'elo',
+    ]);
+    expect(() => parseStrategies(['unknown'])).toThrow(
+      'Invalid strategy "unknown". Expected one of: standard, elo, majority.',
+    );
+  });
+
+  it('handles majority strategy for insufficient and sufficient response counts', async () => {
+    const insufficient = await generateConsensus(
+      ['majority'],
+      'Q',
+      [
+        {
+          provider: 'openai',
+          model: 'a',
+          content: 'A',
+          responseTimeMs: 5,
+        },
+      ],
+      buildProvider(async () => undefined),
+      'judge-model',
+    );
+    expect(insufficient.majority).toContain('requires at least 2');
+
+    let callCount = 0;
+    const provider = buildProvider(async (_prompt, _model, _onChunk, onComplete) => {
+      callCount += 1;
+      if (callCount === 1) {
+        onComplete(
+          JSON.stringify({
+            rankings: [
+              { modelId: 'a', alignmentScore: 90 },
+              { modelId: 'b', alignmentScore: 80 },
+            ],
+          }),
+          5,
+          20,
+        );
+        return;
+      }
+      onComplete('majority answer', 5, 20);
+    });
+    const responses: ProviderResponse[] = [
+      { provider: 'openai', model: 'a', content: 'A', responseTimeMs: 5 },
+      { provider: 'anthropic', model: 'b', content: 'B', responseTimeMs: 6 },
+    ];
+    const sufficient = await generateConsensus(
+      ['majority'],
+      'Q',
+      responses,
+      provider,
+      'judge-model',
+    );
+
+    expect(sufficient.majority).toBe('majority answer');
+  });
+});

--- a/packages/eval/src/lib/ensembleRunner.test.ts
+++ b/packages/eval/src/lib/ensembleRunner.test.ts
@@ -1,0 +1,113 @@
+import type {
+  AIProvider,
+  ProviderRegistry,
+} from '@ensemble-ai/shared-utils/providers';
+import { describe, expect, it } from 'vitest';
+import { EnsembleRunner } from './ensembleRunner.js';
+import type { EvalProvider } from '../types.js';
+
+function buildProvider(args: {
+  onStream: AIProvider['streamResponse'];
+  models?: Array<{ id: string; costPer1kTokens: number }>;
+}): AIProvider {
+  return {
+    streamResponse: args.onStream,
+    generateEmbeddings: async () => [],
+    validateApiKey: async () => ({ valid: true }),
+    listAvailableModels: () =>
+      (args.models ?? []).map((model) => ({
+        id: model.id,
+        name: model.id,
+        provider: 'openai',
+        contextWindow: 128_000,
+        costPer1kTokens: model.costPer1kTokens,
+      })),
+    listAvailableTextModels: async () => [],
+  };
+}
+
+function buildRegistry(providers: Record<EvalProvider, AIProvider>): ProviderRegistry {
+  return {
+    getProvider: (provider: EvalProvider) => providers[provider],
+  } as unknown as ProviderRegistry;
+}
+
+describe('EnsembleRunner', () => {
+  it('collects responses, estimates costs, and keeps failed model runs', async () => {
+    const openaiProvider = buildProvider({
+      onStream: async (_prompt, _model, _onChunk, onComplete) => {
+        onComplete('openai answer', 40, 1200);
+      },
+      models: [{ id: 'gpt-4o', costPer1kTokens: 0.01 }],
+    });
+    const anthropicProvider = buildProvider({
+      onStream: async (_prompt, _model, _onChunk, _onComplete, onError) => {
+        onError(new Error('provider error'));
+      },
+      models: [{ id: 'claude', costPer1kTokens: 0.02 }],
+    });
+
+    const runner = new EnsembleRunner(
+      buildRegistry({
+        openai: openaiProvider,
+        anthropic: anthropicProvider,
+        google: openaiProvider,
+        xai: openaiProvider,
+      }),
+      'mock',
+    );
+
+    const results = await runner.runPrompt('Test prompt', [
+      { provider: 'openai', model: 'gpt-4o' },
+      { provider: 'anthropic', model: 'claude' },
+    ]);
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({
+      provider: 'openai',
+      model: 'gpt-4o',
+      content: 'openai answer',
+      responseTimeMs: 40,
+      tokenCount: 1200,
+    });
+    expect(results[0].estimatedCostUsd).toBeCloseTo(0.012, 10);
+    expect(results[1]).toMatchObject({
+      provider: 'anthropic',
+      model: 'claude',
+      error: 'provider error',
+    });
+  });
+
+  it('supports configurable delay between starting model calls', async () => {
+    const startTimes: number[] = [];
+    const provider = buildProvider({
+      onStream: async (_prompt, _model, _onChunk, onComplete) => {
+        startTimes.push(Date.now());
+        onComplete('ok', 1, 10);
+      },
+      models: [
+        { id: 'model-a', costPer1kTokens: 0.001 },
+        { id: 'model-b', costPer1kTokens: 0.001 },
+      ],
+    });
+
+    const runner = new EnsembleRunner(
+      buildRegistry({
+        openai: provider,
+        anthropic: provider,
+        google: provider,
+        xai: provider,
+      }),
+      'mock',
+      { requestDelayMs: 25 },
+    );
+
+    await runner.runPrompt('Delayed prompt', [
+      { provider: 'openai', model: 'model-a' },
+      { provider: 'openai', model: 'model-b' },
+    ]);
+
+    expect(startTimes).toHaveLength(2);
+    expect(startTimes[1] - startTimes[0]).toBeGreaterThanOrEqual(20);
+  });
+});

--- a/packages/eval/src/lib/evaluation.ts
+++ b/packages/eval/src/lib/evaluation.ts
@@ -4,7 +4,7 @@ import type {
   ProviderResponse,
 } from '../types.js';
 
-interface EvalLike {
+export interface EvaluatorLike {
   name: PromptEvaluation['evaluator'];
   evaluate(
     response: string,
@@ -14,7 +14,7 @@ interface EvalLike {
 }
 
 export async function evaluateResponses(
-  evaluator: EvalLike | null,
+  evaluator: EvaluatorLike | null,
   responses: ProviderResponse[],
   groundTruth: string,
   prompt?: string,

--- a/packages/eval/src/lib/runPrompt.ts
+++ b/packages/eval/src/lib/runPrompt.ts
@@ -1,75 +1,14 @@
-import type {
-  AIProvider,
-  ProviderRegistry,
-} from '@ensemble-ai/shared-utils/providers';
+import type { ProviderRegistry } from '@ensemble-ai/shared-utils/providers';
 import type { EvalMode, ModelSpec, ProviderResponse } from '../types.js';
-
-async function streamModelResponse(
-  client: AIProvider,
-  prompt: string,
-  model: string,
-): Promise<Pick<ProviderResponse, 'content' | 'responseTimeMs' | 'tokenCount' | 'error'>> {
-  return new Promise((resolve) => {
-    let content = '';
-    let settled = false;
-
-    const safeResolve = (
-      value: Pick<ProviderResponse, 'content' | 'responseTimeMs' | 'tokenCount' | 'error'>,
-    ) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      resolve(value);
-    };
-
-    client.streamResponse(
-      prompt,
-      model,
-      (chunk) => {
-        content += chunk;
-      },
-      (fullResponse, responseTime, tokenCount) => {
-        safeResolve({
-          content: fullResponse || content,
-          responseTimeMs: responseTime,
-          tokenCount,
-        });
-      },
-      (error) => {
-        safeResolve({
-          content,
-          responseTimeMs: 0,
-          error: error.message,
-        });
-      },
-    ).catch((error: unknown) => {
-      const message = error instanceof Error ? error.message : String(error);
-      safeResolve({
-        content,
-        responseTimeMs: 0,
-        error: message,
-      });
-    });
-  });
-}
+import { EnsembleRunner } from './ensembleRunner.js';
 
 export async function runPromptWithModels(
   registry: ProviderRegistry,
   mode: EvalMode,
   prompt: string,
   models: ModelSpec[],
+  options?: { requestDelayMs?: number },
 ): Promise<ProviderResponse[]> {
-  const tasks = models.map(async ({ provider, model }) => {
-    const client = registry.getProvider(provider, mode);
-    const result = await streamModelResponse(client, prompt, model);
-
-    return {
-      provider,
-      model,
-      ...result,
-    } satisfies ProviderResponse;
-  });
-
-  return Promise.all(tasks);
+  const runner = new EnsembleRunner(registry, mode, options);
+  return runner.runPrompt(prompt, models);
 }

--- a/packages/eval/src/lib/selfConsistency.test.ts
+++ b/packages/eval/src/lib/selfConsistency.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { buildSelfConsistencyResult } from './selfConsistency.js';
+
+describe('buildSelfConsistencyResult', () => {
+  it('returns undefined when run count is 1', () => {
+    expect(
+      buildSelfConsistencyResult({
+        runCount: 1,
+        responses: [],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('builds majority vote from evaluator predictions', () => {
+    const result = buildSelfConsistencyResult({
+      runCount: 5,
+      responses: [],
+      evaluation: {
+        evaluator: 'mcq',
+        groundTruth: 'B',
+        accuracy: 0.6,
+        results: {
+          a: { correct: true, expected: 'B', predicted: 'B' },
+          b: { correct: false, expected: 'B', predicted: 'A' },
+          c: { correct: true, expected: 'B', predicted: 'B' },
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      runs: 5,
+      majorityAnswer: 'B',
+      majorityCount: 2,
+      correct: true,
+    });
+  });
+
+  it('falls back to successful response content when evaluation is unavailable', () => {
+    const result = buildSelfConsistencyResult({
+      runCount: 3,
+      responses: [
+        {
+          provider: 'openai',
+          model: 'gpt-4o',
+          content: '42',
+          responseTimeMs: 12,
+        },
+        {
+          provider: 'openai',
+          model: 'gpt-4o',
+          content: '42',
+          responseTimeMs: 14,
+        },
+        {
+          provider: 'openai',
+          model: 'gpt-4o',
+          content: '',
+          responseTimeMs: 0,
+          error: 'timeout',
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      runs: 3,
+      majorityAnswer: '42',
+      majorityCount: 2,
+      correct: null,
+    });
+  });
+});

--- a/packages/eval/src/lib/selfConsistency.ts
+++ b/packages/eval/src/lib/selfConsistency.ts
@@ -1,0 +1,60 @@
+import type {
+  PromptEvaluation,
+  ProviderResponse,
+  SelfConsistencyResult,
+} from '../types.js';
+
+function pickMajority(values: string[]): { value: string | null; count: number } {
+  if (values.length === 0) {
+    return { value: null, count: 0 };
+  }
+
+  const counts = new Map<string, number>();
+  for (const value of values) {
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+
+  let majorityValue: string | null = null;
+  let majorityCount = 0;
+  for (const [value, count] of counts.entries()) {
+    if (count > majorityCount) {
+      majorityValue = value;
+      majorityCount = count;
+    }
+  }
+
+  return { value: majorityValue, count: majorityCount };
+}
+
+export function buildSelfConsistencyResult(args: {
+  runCount: number;
+  responses: ProviderResponse[];
+  evaluation?: PromptEvaluation;
+}): SelfConsistencyResult | undefined {
+  if (args.runCount <= 1) {
+    return undefined;
+  }
+
+  const predicted = args.evaluation
+    ? Object.values(args.evaluation.results)
+        .map((result) => result.predicted)
+        .filter((value): value is string => Boolean(value && value.trim().length > 0))
+        .map((value) => value.trim())
+    : args.responses
+        .filter((response) => !response.error && response.content.trim().length > 0)
+        .map((response) => response.content.trim());
+
+  const majority = pickMajority(predicted);
+  const expected = args.evaluation?.groundTruth?.trim();
+  const correct =
+    expected && majority.value !== null
+      ? majority.value.toUpperCase() === expected.toUpperCase()
+      : null;
+
+  return {
+    runs: args.runCount,
+    majorityAnswer: majority.value,
+    majorityCount: majority.count,
+    correct,
+  };
+}

--- a/packages/eval/src/types.ts
+++ b/packages/eval/src/types.ts
@@ -2,7 +2,7 @@ import type { ProviderMode, ProviderName } from '@ensemble-ai/shared-utils/provi
 
 export type EvalProvider = ProviderName;
 export type EvalMode = Extract<ProviderMode, 'mock' | 'free'>;
-export type StrategyName = 'standard' | 'elo';
+export type StrategyName = 'standard' | 'elo' | 'majority';
 export type BenchmarkDatasetName = 'gsm8k' | 'truthfulqa' | 'gpqa';
 
 export interface ModelSpec {
@@ -42,7 +42,15 @@ export interface ProviderResponse {
   content: string;
   responseTimeMs: number;
   tokenCount?: number;
+  estimatedCostUsd?: number;
   error?: string;
+}
+
+export interface SelfConsistencyResult {
+  runs: number;
+  majorityAnswer: string | null;
+  majorityCount: number;
+  correct: boolean | null;
 }
 
 export interface PromptRunResult {
@@ -52,6 +60,7 @@ export interface PromptRunResult {
   responses: ProviderResponse[];
   consensus: Partial<Record<StrategyName, string>>;
   evaluation?: PromptEvaluation;
+  selfConsistency?: SelfConsistencyResult;
 }
 
 export interface BenchmarkResultsFile {


### PR DESCRIPTION
## Summary
- implement `EnsembleRunner` orchestration with:
  - parallel model execution
  - graceful per-model error capture (without aborting the prompt run)
  - timing + token capture and per-response cost estimate (`estimatedCostUsd`)
  - configurable request start delay (`requestDelayMs`) for rate-limiting control
- implement `BenchmarkRunner` orchestration with:
  - per-question execution pipeline (responses, consensus, evaluation)
  - checkpoint persistence after each question
  - resume-safe skipping using `questionId` + legacy prompt fallback
  - progress callback support (wired to benchmark CLI logs)
- wire new runners into CLI commands:
  - `benchmark`: now uses `BenchmarkRunner`, adds `--request-delay-ms`
  - `run`: now uses `EnsembleRunner`, adds `--request-delay-ms`
  - `baseline`: now uses `EnsembleRunner`, adds `--self-consistency-runs` and `--request-delay-ms`
- add self-consistency baseline support (`buildSelfConsistencyResult`) and persist it in run output
- extend consensus strategies to include `majority` end-to-end in eval command parsing/generation
- extend eval types to include `majority` strategy, response cost estimates, and self-consistency result schema

## Tests
- added:
  - `packages/eval/src/lib/ensembleRunner.test.ts`
  - `packages/eval/src/lib/benchmarkRunner.test.ts`
  - `packages/eval/src/lib/selfConsistency.test.ts`
  - `packages/eval/src/lib/consensus.test.ts`
- updated existing coverage through:
  - `npm run typecheck --workspace @ensemble-ai/eval`
  - `npm run test --workspace @ensemble-ai/eval`
  - `npm run test --workspace @ensemble-ai/shared-utils`

Closes #112
