### PR TITLE
feat(eval): add statistical analysis pipeline and chart exports

### DIFF
--- a/packages/eval/src/commands/analyze.ts
+++ b/packages/eval/src/commands/analyze.ts
@@ -1,10 +1,13 @@
 import { Command } from 'commander';
+import { analyzeBenchmarkRuns } from '../lib/analysis.js';
 import { createMarkdownReport } from '../lib/report.js';
-import { readJsonFile, writeTextFile } from '../lib/io.js';
+import { readJsonFile, writeJsonFile, writeTextFile } from '../lib/io.js';
 import type { PromptRunResult } from '../types.js';
 
 interface AnalyzeCommandOptions {
   report: string;
+  charts?: string;
+  bootstrapIterations?: string;
 }
 
 interface ResultFileWithRuns {
@@ -17,16 +20,57 @@ export function createAnalyzeCommand(): Command {
     .description('Analyze a JSON result file and generate a Markdown report.')
     .argument('<results>', 'Path to benchmark/baseline JSON output')
     .requiredOption('--report <file>', 'Markdown report output path')
+    .option('--charts <dir>', 'Directory for chart-ready JSON output files')
+    .option(
+      '--bootstrap-iterations <count>',
+      'Paired bootstrap iterations for confidence intervals.',
+      '10000',
+    )
     .action(async (results: string, options: AnalyzeCommandOptions) => {
       const parsed = await readJsonFile<ResultFileWithRuns>(results);
       if (!parsed || !Array.isArray(parsed.runs)) {
         throw new Error(`Result file does not contain a valid "runs" array: ${results}`);
       }
+      const bootstrapIterations = Number.parseInt(
+        options.bootstrapIterations ?? '10000',
+        10,
+      );
+      if (!Number.isInteger(bootstrapIterations) || bootstrapIterations <= 0) {
+        throw new Error(
+          `Invalid bootstrap iteration count "${options.bootstrapIterations}".`,
+        );
+      }
 
-      const markdown = createMarkdownReport(results, parsed.runs);
+      const analysis = analyzeBenchmarkRuns(parsed.runs, { bootstrapIterations });
+      const markdown = createMarkdownReport(results, analysis);
       await writeTextFile(options.report, markdown);
+      if (options.charts) {
+        await writeJsonFile(
+          `${options.charts}/accuracy-lift-by-difficulty.json`,
+          analysis.charts.accuracyLiftByDifficulty,
+        );
+        await writeJsonFile(
+          `${options.charts}/agreement-calibration.json`,
+          analysis.charts.agreementCalibration,
+        );
+        await writeJsonFile(
+          `${options.charts}/model-diversity-heatmap.json`,
+          analysis.charts.modelDiversityHeatmap,
+        );
+        await writeJsonFile(
+          `${options.charts}/cost-vs-accuracy-frontier.json`,
+          analysis.charts.costVsAccuracyFrontier,
+        );
+        await writeJsonFile(
+          `${options.charts}/right-answer-always-there.json`,
+          analysis.charts.rightAnswerAlwaysThere,
+        );
+      }
 
       process.stdout.write(`Report generated: ${options.report}\n`);
+      if (options.charts) {
+        process.stdout.write(`Chart JSON written to ${options.charts}\n`);
+      }
     });
 
   return command;

--- a/packages/eval/src/commands/baseline.ts
+++ b/packages/eval/src/commands/baseline.ts
@@ -94,6 +94,8 @@ export function createBaselineCommand(): Command {
           questionId: question.id,
           prompt: question.prompt,
           groundTruth: question.groundTruth,
+          category: question.category,
+          difficulty: question.difficulty,
           responses,
           consensus: {},
           evaluation,

--- a/packages/eval/src/index.ts
+++ b/packages/eval/src/index.ts
@@ -8,3 +8,5 @@ export * from './lib/report.js';
 export * from './lib/ensembleRunner.js';
 export * from './lib/benchmarkRunner.js';
 export * from './lib/selfConsistency.js';
+export * from './lib/analysis.js';
+export * from './lib/statistics.js';

--- a/packages/eval/src/lib/analysis.test.ts
+++ b/packages/eval/src/lib/analysis.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeBenchmarkRuns } from './analysis.js';
+import type { PromptRunResult } from '../types.js';
+
+function makeRun(args: {
+  id: string;
+  prompt: string;
+  groundTruth: string;
+  modelA: { predicted: string; correct: boolean };
+  modelB: { predicted: string; correct: boolean };
+  strategyAnswer: string;
+  category: string;
+  difficulty: string;
+}): PromptRunResult {
+  return {
+    questionId: args.id,
+    prompt: args.prompt,
+    groundTruth: args.groundTruth,
+    category: args.category,
+    difficulty: args.difficulty,
+    responses: [
+      {
+        provider: 'openai',
+        model: 'gpt-4o',
+        content: args.modelA.predicted,
+        responseTimeMs: 10,
+        tokenCount: 100,
+        estimatedCostUsd: 0.001,
+      },
+      {
+        provider: 'anthropic',
+        model: 'claude',
+        content: args.modelB.predicted,
+        responseTimeMs: 12,
+        tokenCount: 90,
+        estimatedCostUsd: 0.002,
+      },
+    ],
+    consensus: {
+      standard: args.strategyAnswer,
+    },
+    evaluation: {
+      evaluator: 'numeric',
+      groundTruth: args.groundTruth,
+      accuracy: 0,
+      results: {
+        'openai:gpt-4o': {
+          predicted: args.modelA.predicted,
+          expected: args.groundTruth,
+          correct: args.modelA.correct,
+        },
+        'anthropic:claude': {
+          predicted: args.modelB.predicted,
+          expected: args.groundTruth,
+          correct: args.modelB.correct,
+        },
+      },
+    },
+  };
+}
+
+describe('analyzeBenchmarkRuns', () => {
+  it('builds model/strategy accuracy, stats, and chart payloads', () => {
+    const analysis = analyzeBenchmarkRuns(
+      [
+        makeRun({
+          id: 'q1',
+          prompt: 'one',
+          groundTruth: '1',
+          modelA: { predicted: '1', correct: true },
+          modelB: { predicted: '0', correct: false },
+          strategyAnswer: '1',
+          category: 'math',
+          difficulty: 'easy',
+        }),
+        makeRun({
+          id: 'q2',
+          prompt: 'two',
+          groundTruth: '2',
+          modelA: { predicted: '0', correct: false },
+          modelB: { predicted: '0', correct: false },
+          strategyAnswer: '2',
+          category: 'math',
+          difficulty: 'hard',
+        }),
+        makeRun({
+          id: 'q3',
+          prompt: 'three',
+          groundTruth: '3',
+          modelA: { predicted: '3', correct: true },
+          modelB: { predicted: '3', correct: true },
+          strategyAnswer: '0',
+          category: 'science',
+          difficulty: 'hard',
+        }),
+      ],
+      { bootstrapIterations: 200 },
+    );
+
+    expect(analysis.primaryStrategy).toBe('standard');
+    expect(analysis.modelAccuracy.map((row) => row.label)).toEqual([
+      'openai:gpt-4o',
+      'anthropic:claude',
+    ]);
+    expect(analysis.strategyAccuracy[0]).toMatchObject({
+      label: 'standard',
+      correct: 2,
+      total: 3,
+    });
+    expect(analysis.comparisons).not.toHaveLength(0);
+    expect(analysis.notableExamples.map((example) => example.questionId)).toContain('q2');
+    expect(analysis.charts.costVsAccuracyFrontier.length).toBeGreaterThanOrEqual(3);
+    expect(analysis.charts.modelDiversityHeatmap.models).toHaveLength(2);
+  });
+});

--- a/packages/eval/src/lib/analysis.ts
+++ b/packages/eval/src/lib/analysis.ts
@@ -1,0 +1,105 @@
+import type { PromptRunResult } from '../types.js';
+import { pickPrimaryStrategy } from './analysisHelpers.js';
+import {
+  collectAnalysisAggregates,
+  type QuestionSummary,
+} from './analysisAggregates.js';
+import { buildComparisonStats } from './analysisComparisons.js';
+import { buildModelDiversityHeatmap, buildRightAnswerAlwaysThereStats } from './analysisCharts.js';
+import { buildAgreementRows, buildBreakdownRows, buildCostRows, toAccuracyRows } from './analysisRows.js';
+import type { AnalysisSummary, NotableExample } from './analysisTypes.js';
+
+interface AnalyzeOptions {
+  bootstrapIterations?: number;
+}
+
+function buildNotableExamples(
+  questions: QuestionSummary[],
+  primaryStrategy: string | null,
+): NotableExample[] {
+  if (!primaryStrategy) {
+    return [];
+  }
+
+  return questions
+    .filter((question) => {
+      const strategy = question.strategyResults[primaryStrategy];
+      const modelCorrect = Object.values(question.modelResults).some((entry) => entry.correct);
+      return strategy?.correct === true && !modelCorrect;
+    })
+    .slice(0, 5)
+    .map((question) => ({
+      questionId: question.questionId,
+      prompt: question.prompt,
+      groundTruth: question.groundTruth,
+      strategy: primaryStrategy,
+      ensembleAnswer: question.strategyResults[primaryStrategy].predicted,
+      modelAccuracies: Object.fromEntries(
+        Object.entries(question.modelResults).map(([model, value]) => [model, value.correct]),
+      ),
+    }));
+}
+
+export function analyzeBenchmarkRuns(
+  runs: PromptRunResult[],
+  options?: AnalyzeOptions,
+): AnalysisSummary {
+  const bootstrapIterations = options?.bootstrapIterations ?? 10_000;
+  const primaryStrategy = pickPrimaryStrategy(runs);
+  const aggregates = collectAnalysisAggregates(runs);
+
+  const modelAccuracy = toAccuracyRows(aggregates.modelCounts);
+  const strategyAccuracy = toAccuracyRows(aggregates.strategyCounts);
+  const categoryBreakdown = buildBreakdownRows('category', aggregates.questions, primaryStrategy);
+  const difficultyBreakdown = buildBreakdownRows('difficulty', aggregates.questions, primaryStrategy);
+  const agreementCalibration = buildAgreementRows(aggregates.agreementBins);
+  const comparisons = buildComparisonStats(
+    aggregates.questions,
+    primaryStrategy,
+    modelAccuracy.map((row) => row.label),
+    bootstrapIterations,
+  );
+
+  return {
+    promptCount: runs.length,
+    modelAccuracy,
+    strategyAccuracy,
+    comparisons,
+    agreementCalibration,
+    categoryBreakdown,
+    difficultyBreakdown,
+    notableExamples: buildNotableExamples(aggregates.questions, primaryStrategy),
+    costAnalysis: buildCostRows(runs, aggregates.modelCosts, aggregates.strategyCosts),
+    charts: {
+      accuracyLiftByDifficulty: difficultyBreakdown.map((row) => ({
+        difficulty: row.key,
+        lift: row.lift,
+        sampleSize: row.sampleSize,
+      })),
+      agreementCalibration,
+      modelDiversityHeatmap: buildModelDiversityHeatmap(
+        aggregates.questions,
+        modelAccuracy.map((row) => row.label),
+      ),
+      costVsAccuracyFrontier: [
+        ...modelAccuracy.map((row) => ({
+          label: row.label,
+          type: 'model' as const,
+          accuracy: row.accuracy,
+          totalEstimatedCostUsd: aggregates.modelCosts.get(row.label)?.costUsd ?? 0,
+        })),
+        ...strategyAccuracy.map((row) => ({
+          label: row.label,
+          type: 'strategy' as const,
+          accuracy: row.accuracy,
+          totalEstimatedCostUsd: aggregates.strategyCosts.get(row.label)?.costUsd ?? 0,
+        })),
+      ],
+      rightAnswerAlwaysThere: buildRightAnswerAlwaysThereStats(
+        aggregates.questions,
+        primaryStrategy,
+      ),
+    },
+    primaryStrategy,
+  };
+}

--- a/packages/eval/src/lib/analysisAggregates.ts
+++ b/packages/eval/src/lib/analysisAggregates.ts
@@ -1,0 +1,169 @@
+import type { PromptRunResult } from '../types.js';
+import {
+  collectModelResults,
+  evaluateConsensusAnswer,
+  responseCostTotals,
+} from './analysisHelpers.js';
+
+export interface AccuracyCounter {
+  correct: number;
+  total: number;
+}
+
+export interface CostCounter {
+  tokens: number;
+  costUsd: number;
+}
+
+export interface AgreementCounter {
+  ratio: number;
+  correct: number;
+  total: number;
+}
+
+export interface QuestionSummary {
+  questionId: string;
+  prompt: string;
+  groundTruth: string;
+  category: string;
+  difficulty: string;
+  modelResults: Record<string, { predicted: string | null; correct: boolean }>;
+  strategyResults: Record<string, { predicted: string; correct: boolean | null }>;
+}
+
+export interface AnalysisAggregates {
+  questions: QuestionSummary[];
+  modelCounts: Map<string, AccuracyCounter>;
+  strategyCounts: Map<string, AccuracyCounter>;
+  modelCosts: Map<string, CostCounter>;
+  strategyCosts: Map<string, CostCounter>;
+  agreementBins: Map<string, AgreementCounter>;
+}
+
+function incrementAccuracy(
+  map: Map<string, AccuracyCounter>,
+  key: string,
+  isCorrect: boolean,
+): void {
+  const row = map.get(key) ?? { correct: 0, total: 0 };
+  row.total += 1;
+  row.correct += isCorrect ? 1 : 0;
+  map.set(key, row);
+}
+
+function incrementCost(
+  map: Map<string, CostCounter>,
+  key: string,
+  tokens: number,
+  costUsd: number,
+): void {
+  const row = map.get(key) ?? { tokens: 0, costUsd: 0 };
+  row.tokens += tokens;
+  row.costUsd += costUsd;
+  map.set(key, row);
+}
+
+function updateAgreementBin(
+  run: PromptRunResult,
+  groundTruth: string,
+  modelResults: Record<string, { predicted: string | null; correct: boolean }>,
+  agreementBins: Map<string, AgreementCounter>,
+): void {
+  const predictions = Object.values(modelResults)
+    .map((result) => result.predicted?.trim().toUpperCase())
+    .filter((value): value is string => Boolean(value));
+  if (predictions.length === 0) {
+    return;
+  }
+
+  const counts = new Map<string, number>();
+  for (const prediction of predictions) {
+    counts.set(prediction, (counts.get(prediction) ?? 0) + 1);
+  }
+  const maxCount = Math.max(...counts.values());
+  const level = `${maxCount}/${predictions.length}`;
+  const ratio = maxCount / predictions.length;
+  const majorityPrediction = [...counts.entries()].sort((left, right) => right[1] - left[1])[0][0];
+  const majorityEval = evaluateConsensusAnswer(
+    run.evaluation?.evaluator,
+    majorityPrediction,
+    groundTruth,
+  );
+  if (!majorityEval) {
+    return;
+  }
+
+  const bin = agreementBins.get(level) ?? { ratio, correct: 0, total: 0 };
+  bin.total += 1;
+  bin.correct += majorityEval.correct ? 1 : 0;
+  agreementBins.set(level, bin);
+}
+
+export function collectAnalysisAggregates(runs: PromptRunResult[]): AnalysisAggregates {
+  const modelCounts = new Map<string, AccuracyCounter>();
+  const strategyCounts = new Map<string, AccuracyCounter>();
+  const modelCosts = new Map<string, CostCounter>();
+  const strategyCosts = new Map<string, CostCounter>();
+  const agreementBins = new Map<string, AgreementCounter>();
+  const questions: QuestionSummary[] = [];
+
+  for (const run of runs) {
+    const groundTruth = run.evaluation?.groundTruth ?? run.groundTruth ?? '';
+    const modelResults = collectModelResults(run);
+    for (const [model, result] of Object.entries(modelResults)) {
+      incrementAccuracy(modelCounts, model, result.correct);
+    }
+
+    for (const response of run.responses) {
+      if (response.error) {
+        continue;
+      }
+      incrementCost(
+        modelCosts,
+        `${response.provider}:${response.model}`,
+        response.tokenCount ?? 0,
+        response.estimatedCostUsd ?? 0,
+      );
+    }
+
+    const strategyResults: QuestionSummary['strategyResults'] = {};
+    const runCost = responseCostTotals(run);
+    for (const [strategy, answer] of Object.entries(run.consensus)) {
+      const evaluated = evaluateConsensusAnswer(
+        run.evaluation?.evaluator,
+        answer,
+        groundTruth,
+      );
+      strategyResults[strategy] = { predicted: answer, correct: evaluated?.correct ?? null };
+      if (evaluated) {
+        incrementAccuracy(strategyCounts, strategy, evaluated.correct);
+      }
+      incrementCost(strategyCosts, strategy, runCost.tokens, runCost.costUsd);
+    }
+
+    updateAgreementBin(run, groundTruth, modelResults, agreementBins);
+    questions.push({
+      questionId: run.questionId ?? run.prompt,
+      prompt: run.prompt,
+      groundTruth,
+      category: run.category ?? 'uncategorized',
+      difficulty: run.difficulty ?? 'unknown',
+      modelResults: Object.fromEntries(
+        Object.entries(modelResults).map(([model, result]) => [
+          model,
+          { predicted: result.predicted, correct: result.correct },
+        ]),
+      ),
+      strategyResults,
+    });
+  }
+
+  return {
+    questions,
+    modelCounts,
+    strategyCounts,
+    modelCosts,
+    strategyCosts,
+    agreementBins,
+  };
+}

--- a/packages/eval/src/lib/analysisCharts.ts
+++ b/packages/eval/src/lib/analysisCharts.ts
@@ -1,0 +1,79 @@
+import type { ChartBundle } from './analysisTypes.js';
+import { safeRatio } from './analysisHelpers.js';
+
+interface QuestionForCharts {
+  modelResults: Record<string, { predicted: string | null; correct: boolean }>;
+  strategyResults: Record<string, { correct: boolean | null }>;
+}
+
+export function buildModelDiversityHeatmap(
+  questions: QuestionForCharts[],
+  models: string[],
+): { models: string[]; matrix: number[][] } {
+  const matrix = models.map(() => models.map(() => 1));
+
+  for (let i = 0; i < models.length; i += 1) {
+    for (let j = i + 1; j < models.length; j += 1) {
+      const leftModel = models[i];
+      const rightModel = models[j];
+
+      let compared = 0;
+      let matches = 0;
+      for (const question of questions) {
+        const left = question.modelResults[leftModel]?.predicted;
+        const right = question.modelResults[rightModel]?.predicted;
+        if (!left || !right) {
+          continue;
+        }
+
+        compared += 1;
+        if (left.trim().toUpperCase() === right.trim().toUpperCase()) {
+          matches += 1;
+        }
+      }
+
+      const agreement = safeRatio(matches, compared);
+      matrix[i][j] = agreement;
+      matrix[j][i] = agreement;
+    }
+  }
+
+  return { models, matrix };
+}
+
+export function buildRightAnswerAlwaysThereStats(
+  questions: QuestionForCharts[],
+  primaryStrategy: string | null,
+): ChartBundle['rightAnswerAlwaysThere'] {
+  let alwaysThereCount = 0;
+  let recoveredByEnsembleCount = 0;
+  let missedDespiteAvailabilityCount = 0;
+  let ensembleSolvedWhenAllFailedCount = 0;
+
+  for (const question of questions) {
+    const modelCorrect = Object.values(question.modelResults).map((entry) => entry.correct);
+    const atLeastOneCorrect = modelCorrect.some(Boolean);
+    const strategyCorrect = primaryStrategy
+      ? question.strategyResults[primaryStrategy]?.correct ?? null
+      : null;
+
+    if (atLeastOneCorrect) {
+      alwaysThereCount += 1;
+      if (strategyCorrect === true) {
+        recoveredByEnsembleCount += 1;
+      } else if (strategyCorrect === false) {
+        missedDespiteAvailabilityCount += 1;
+      }
+    } else if (strategyCorrect === true) {
+      ensembleSolvedWhenAllFailedCount += 1;
+    }
+  }
+
+  return {
+    totalQuestions: questions.length,
+    alwaysThereCount,
+    recoveredByEnsembleCount,
+    missedDespiteAvailabilityCount,
+    ensembleSolvedWhenAllFailedCount,
+  };
+}

--- a/packages/eval/src/lib/analysisComparisons.ts
+++ b/packages/eval/src/lib/analysisComparisons.ts
@@ -1,0 +1,58 @@
+import { computeMcNemar, computePairedBootstrapDelta } from './statistics.js';
+import type { ComparisonStats } from './analysisTypes.js';
+import type { QuestionSummary } from './analysisAggregates.js';
+
+interface PairedOutcome {
+  modelCorrect: boolean;
+  strategyCorrect: boolean;
+}
+
+function extractPairs(
+  questions: QuestionSummary[],
+  model: string,
+  strategy: string,
+): PairedOutcome[] {
+  return questions
+    .map((question) => {
+      const modelResult = question.modelResults[model];
+      const strategyResult = question.strategyResults[strategy];
+      if (!modelResult || !strategyResult || strategyResult.correct === null) {
+        return null;
+      }
+      return {
+        modelCorrect: modelResult.correct,
+        strategyCorrect: strategyResult.correct,
+      };
+    })
+    .filter((value): value is PairedOutcome => Boolean(value));
+}
+
+export function buildComparisonStats(
+  questions: QuestionSummary[],
+  primaryStrategy: string | null,
+  models: string[],
+  bootstrapIterations: number,
+): ComparisonStats[] {
+  if (!primaryStrategy) {
+    return [];
+  }
+
+  const comparisons: ComparisonStats[] = [];
+  for (const model of models) {
+    const pairs = extractPairs(questions, model, primaryStrategy);
+    if (pairs.length === 0) {
+      continue;
+    }
+    comparisons.push({
+      comparedAgainst: model,
+      sampleSize: pairs.length,
+      mcnemar: computeMcNemar(pairs),
+      bootstrap: {
+        ...computePairedBootstrapDelta(pairs, bootstrapIterations),
+        iterations: bootstrapIterations,
+      },
+    });
+  }
+
+  return comparisons;
+}

--- a/packages/eval/src/lib/analysisHelpers.ts
+++ b/packages/eval/src/lib/analysisHelpers.ts
@@ -1,0 +1,84 @@
+import type { EvaluationResult, PromptRunResult } from '../types.js';
+import { MCQEvaluator, NumericEvaluator } from './evaluators.js';
+
+const numericEvaluator = new NumericEvaluator();
+const mcqEvaluator = new MCQEvaluator();
+
+function normalizeModelKey(key: string): string {
+  return key.replace(/#\d+$/, '');
+}
+
+export function evaluateConsensusAnswer(
+  evaluator: 'numeric' | 'mcq' | 'generative' | undefined,
+  answer: string,
+  groundTruth: string,
+): EvaluationResult | null {
+  if (!answer || !groundTruth) {
+    return null;
+  }
+
+  if (evaluator === 'numeric') {
+    return numericEvaluator.evaluate(answer, groundTruth);
+  }
+  if (evaluator === 'mcq') {
+    return mcqEvaluator.evaluate(answer, groundTruth);
+  }
+  return null;
+}
+
+export function collectModelResults(run: PromptRunResult): Record<string, EvaluationResult> {
+  if (!run.evaluation) {
+    return {};
+  }
+
+  const firstByModel = new Map<string, EvaluationResult>();
+  for (const [rawKey, result] of Object.entries(run.evaluation.results)) {
+    const modelKey = normalizeModelKey(rawKey);
+    if (!firstByModel.has(modelKey)) {
+      firstByModel.set(modelKey, result);
+    }
+  }
+
+  return Object.fromEntries(firstByModel.entries());
+}
+
+export function responseCostTotals(run: PromptRunResult): {
+  tokens: number;
+  costUsd: number;
+} {
+  let tokens = 0;
+  let costUsd = 0;
+  for (const response of run.responses) {
+    if (response.error) {
+      continue;
+    }
+    tokens += response.tokenCount ?? 0;
+    costUsd += response.estimatedCostUsd ?? 0;
+  }
+  return { tokens, costUsd };
+}
+
+export function safeRatio(numerator: number, denominator: number): number {
+  return denominator === 0 ? 0 : numerator / denominator;
+}
+
+export function pickPrimaryStrategy(runs: PromptRunResult[]): string | null {
+  const seen = new Set<string>();
+  for (const run of runs) {
+    for (const strategy of Object.keys(run.consensus)) {
+      seen.add(strategy);
+    }
+  }
+
+  if (seen.has('standard')) {
+    return 'standard';
+  }
+  if (seen.has('majority')) {
+    return 'majority';
+  }
+  if (seen.has('elo')) {
+    return 'elo';
+  }
+  const first = [...seen][0];
+  return first ?? null;
+}

--- a/packages/eval/src/lib/analysisRows.ts
+++ b/packages/eval/src/lib/analysisRows.ts
@@ -1,0 +1,121 @@
+import type { PromptRunResult } from '../types.js';
+import { safeRatio } from './analysisHelpers.js';
+import type {
+  AccuracyRow,
+  AgreementCalibrationRow,
+  BreakdownRow,
+  CostRow,
+} from './analysisTypes.js';
+import type {
+  AccuracyCounter,
+  AgreementCounter,
+  CostCounter,
+  QuestionSummary,
+} from './analysisAggregates.js';
+
+export function toAccuracyRows(map: Map<string, AccuracyCounter>): AccuracyRow[] {
+  return [...map.entries()]
+    .map(([label, value]) => ({
+      label,
+      correct: value.correct,
+      total: value.total,
+      accuracy: safeRatio(value.correct, value.total),
+    }))
+    .sort(
+      (left, right) =>
+        right.accuracy - left.accuracy || left.label.localeCompare(right.label),
+    );
+}
+
+export function buildBreakdownRows(
+  key: 'category' | 'difficulty',
+  questions: QuestionSummary[],
+  primaryStrategy: string | null,
+): BreakdownRow[] {
+  const grouped = new Map<string, QuestionSummary[]>();
+  for (const question of questions) {
+    const groupKey = key === 'category' ? question.category : question.difficulty;
+    const bucket = grouped.get(groupKey) ?? [];
+    bucket.push(question);
+    grouped.set(groupKey, bucket);
+  }
+
+  return [...grouped.entries()]
+    .map(([groupKey, groupQuestions]) => {
+      let bestModelAccuracy = 0;
+      const models = new Set(groupQuestions.flatMap((question) => Object.keys(question.modelResults)));
+      for (const model of models) {
+        let correct = 0;
+        let total = 0;
+        for (const question of groupQuestions) {
+          const result = question.modelResults[model];
+          if (!result) {
+            continue;
+          }
+          total += 1;
+          correct += result.correct ? 1 : 0;
+        }
+        bestModelAccuracy = Math.max(bestModelAccuracy, safeRatio(correct, total));
+      }
+
+      let ensembleCorrect = 0;
+      let ensembleTotal = 0;
+      if (primaryStrategy) {
+        for (const question of groupQuestions) {
+          const strategy = question.strategyResults[primaryStrategy];
+          if (!strategy || strategy.correct === null) {
+            continue;
+          }
+          ensembleTotal += 1;
+          ensembleCorrect += strategy.correct ? 1 : 0;
+        }
+      }
+      const ensembleAccuracy = safeRatio(ensembleCorrect, ensembleTotal);
+
+      return {
+        key: groupKey,
+        sampleSize: groupQuestions.length,
+        bestModelAccuracy,
+        ensembleAccuracy,
+        lift: ensembleAccuracy - bestModelAccuracy,
+      };
+    })
+    .sort((left, right) => left.key.localeCompare(right.key));
+}
+
+export function buildAgreementRows(
+  bins: Map<string, AgreementCounter>,
+): AgreementCalibrationRow[] {
+  return [...bins.entries()]
+    .map(([level, value]) => ({
+      level,
+      ratio: value.ratio,
+      correct: value.correct,
+      total: value.total,
+      accuracy: safeRatio(value.correct, value.total),
+    }))
+    .sort((left, right) => left.ratio - right.ratio || left.level.localeCompare(right.level));
+}
+
+export function buildCostRows(
+  runs: PromptRunResult[],
+  modelCosts: Map<string, CostCounter>,
+  strategyCosts: Map<string, CostCounter>,
+): CostRow[] {
+  const rows = [
+    ...[...modelCosts.entries()].map(([label, values]) => ({
+      label,
+      totalTokens: values.tokens,
+      totalEstimatedCostUsd: values.costUsd,
+      averageCostPerQuestionUsd: safeRatio(values.costUsd, runs.length),
+    })),
+    ...[...strategyCosts.entries()].map(([label, values]) => ({
+      label: `strategy:${label}`,
+      totalTokens: values.tokens,
+      totalEstimatedCostUsd: values.costUsd,
+      averageCostPerQuestionUsd: safeRatio(values.costUsd, runs.length),
+    })),
+  ];
+
+  return rows.sort((left, right) => left.label.localeCompare(right.label));
+}

--- a/packages/eval/src/lib/analysisTypes.ts
+++ b/packages/eval/src/lib/analysisTypes.ts
@@ -1,0 +1,93 @@
+export interface AccuracyRow {
+  label: string;
+  correct: number;
+  total: number;
+  accuracy: number;
+}
+
+export interface ComparisonStats {
+  comparedAgainst: string;
+  sampleSize: number;
+  mcnemar: {
+    n11: number;
+    n10: number;
+    n01: number;
+    n00: number;
+    chiSquared: number;
+    pValue: number;
+  };
+  bootstrap: {
+    meanDelta: number;
+    ciLow: number;
+    ciHigh: number;
+    iterations: number;
+  };
+}
+
+export interface AgreementCalibrationRow {
+  level: string;
+  ratio: number;
+  correct: number;
+  total: number;
+  accuracy: number;
+}
+
+export interface BreakdownRow {
+  key: string;
+  sampleSize: number;
+  bestModelAccuracy: number;
+  ensembleAccuracy: number;
+  lift: number;
+}
+
+export interface NotableExample {
+  questionId: string;
+  prompt: string;
+  groundTruth: string;
+  strategy: string;
+  ensembleAnswer: string;
+  modelAccuracies: Record<string, boolean>;
+}
+
+export interface CostRow {
+  label: string;
+  totalTokens: number;
+  totalEstimatedCostUsd: number;
+  averageCostPerQuestionUsd: number;
+}
+
+export interface ChartBundle {
+  accuracyLiftByDifficulty: Array<{ difficulty: string; lift: number; sampleSize: number }>;
+  agreementCalibration: Array<{ ratio: number; accuracy: number; total: number; level: string }>;
+  modelDiversityHeatmap: {
+    models: string[];
+    matrix: number[][];
+  };
+  costVsAccuracyFrontier: Array<{
+    label: string;
+    type: 'model' | 'strategy';
+    accuracy: number;
+    totalEstimatedCostUsd: number;
+  }>;
+  rightAnswerAlwaysThere: {
+    totalQuestions: number;
+    alwaysThereCount: number;
+    recoveredByEnsembleCount: number;
+    missedDespiteAvailabilityCount: number;
+    ensembleSolvedWhenAllFailedCount: number;
+  };
+}
+
+export interface AnalysisSummary {
+  promptCount: number;
+  modelAccuracy: AccuracyRow[];
+  strategyAccuracy: AccuracyRow[];
+  comparisons: ComparisonStats[];
+  agreementCalibration: AgreementCalibrationRow[];
+  categoryBreakdown: BreakdownRow[];
+  difficultyBreakdown: BreakdownRow[];
+  notableExamples: NotableExample[];
+  costAnalysis: CostRow[];
+  charts: ChartBundle;
+  primaryStrategy: string | null;
+}

--- a/packages/eval/src/lib/benchmarkRunner.ts
+++ b/packages/eval/src/lib/benchmarkRunner.ts
@@ -111,6 +111,8 @@ export class BenchmarkRunner {
         questionId: question.id,
         prompt: question.prompt,
         groundTruth: question.groundTruth,
+        category: question.category,
+        difficulty: question.difficulty,
         responses,
         consensus,
         evaluation,

--- a/packages/eval/src/lib/report.ts
+++ b/packages/eval/src/lib/report.ts
@@ -1,80 +1,115 @@
-import type { PromptRunResult, ProviderResponse } from '../types.js';
+import type { AnalysisSummary } from './analysisTypes.js';
 
-function average(values: number[]): number {
-  if (values.length === 0) {
-    return 0;
+function toPercent(value: number): string {
+  return `${(value * 100).toFixed(2)}%`;
+}
+
+function toUsd(value: number): string {
+  return `$${value.toFixed(4)}`;
+}
+
+function linesForAccuracyTable(title: string, rows: AnalysisSummary['modelAccuracy']): string[] {
+  const lines = [title, '', '| Label | Accuracy | Correct / Total |', '| --- | ---: | ---: |'];
+  for (const row of rows) {
+    lines.push(`| ${row.label} | ${toPercent(row.accuracy)} | ${row.correct} / ${row.total} |`);
   }
-  return values.reduce((total, value) => total + value, 0) / values.length;
-}
-
-function toMs(value: number): string {
-  return `${Math.round(value)} ms`;
-}
-
-function summarizeResponses(responses: ProviderResponse[]): {
-  successful: number;
-  failed: number;
-  averageResponseTimeMs: number;
-  averageTokenCount: number;
-} {
-  const successful = responses.filter((response) => !response.error);
-  const failed = responses.length - successful.length;
-
-  const responseTimes = successful
-    .map((response) => response.responseTimeMs)
-    .filter((value) => value > 0);
-
-  const tokenCounts = successful
-    .map((response) => response.tokenCount ?? 0)
-    .filter((value) => value > 0);
-
-  return {
-    successful: successful.length,
-    failed,
-    averageResponseTimeMs: average(responseTimes),
-    averageTokenCount: average(tokenCounts),
-  };
+  lines.push('');
+  return lines;
 }
 
 export function createMarkdownReport(
   sourceFile: string,
-  runs: PromptRunResult[],
+  analysis: AnalysisSummary,
 ): string {
-  const allResponses = runs.flatMap((run) => run.responses);
-  const summary = summarizeResponses(allResponses);
-
   const lines: string[] = [];
-  lines.push('# Ensemble Eval Report');
+  lines.push('# Ensemble Eval Analysis Report');
   lines.push('');
   lines.push(`Source: \`${sourceFile}\``);
+  lines.push(`Prompts analyzed: ${analysis.promptCount}`);
+  lines.push(`Primary strategy: ${analysis.primaryStrategy ?? 'n/a'}`);
   lines.push('');
-  lines.push('## Run Summary');
-  lines.push('');
-  lines.push(`- Prompts evaluated: ${runs.length}`);
-  lines.push(`- Successful responses: ${summary.successful}`);
-  lines.push(`- Failed responses: ${summary.failed}`);
-  lines.push(`- Average response time: ${toMs(summary.averageResponseTimeMs)}`);
+
+  lines.push(...linesForAccuracyTable('## Accuracy Summary - Models', analysis.modelAccuracy));
   lines.push(
-    `- Average token count (successful responses): ${Math.round(summary.averageTokenCount)}`,
+    ...linesForAccuracyTable('## Accuracy Summary - Ensemble Strategies', analysis.strategyAccuracy),
+  );
+
+  lines.push('## Statistical Significance');
+  lines.push('');
+  if (analysis.comparisons.length === 0) {
+    lines.push('- No model/strategy overlap available for paired tests.');
+  } else {
+    for (const comparison of analysis.comparisons) {
+      lines.push(`- ${comparison.comparedAgainst} (n=${comparison.sampleSize})`);
+      lines.push(
+        `  - McNemar p-value: ${comparison.mcnemar.pValue.toExponential(3)}, chi-squared=${comparison.mcnemar.chiSquared.toFixed(4)}`,
+      );
+      lines.push(
+        `  - Bootstrap delta: ${toPercent(comparison.bootstrap.meanDelta)} (95% CI ${toPercent(comparison.bootstrap.ciLow)} to ${toPercent(comparison.bootstrap.ciHigh)})`,
+      );
+    }
+  }
+  lines.push('');
+
+  lines.push('## Agreement Calibration');
+  lines.push('');
+  lines.push('| Agreement Level | Accuracy | Correct / Total |');
+  lines.push('| --- | ---: | ---: |');
+  for (const row of analysis.agreementCalibration) {
+    lines.push(`| ${row.level} | ${toPercent(row.accuracy)} | ${row.correct} / ${row.total} |`);
+  }
+  lines.push('');
+
+  lines.push('## Category Breakdown');
+  lines.push('');
+  lines.push('| Category | Best Model | Ensemble | Lift | n |');
+  lines.push('| --- | ---: | ---: | ---: | ---: |');
+  for (const row of analysis.categoryBreakdown) {
+    lines.push(
+      `| ${row.key} | ${toPercent(row.bestModelAccuracy)} | ${toPercent(row.ensembleAccuracy)} | ${toPercent(row.lift)} | ${row.sampleSize} |`,
+    );
+  }
+  lines.push('');
+
+  lines.push('## Difficulty Breakdown');
+  lines.push('');
+  lines.push('| Difficulty | Best Model | Ensemble | Lift | n |');
+  lines.push('| --- | ---: | ---: | ---: | ---: |');
+  for (const row of analysis.difficultyBreakdown) {
+    lines.push(
+      `| ${row.key} | ${toPercent(row.bestModelAccuracy)} | ${toPercent(row.ensembleAccuracy)} | ${toPercent(row.lift)} | ${row.sampleSize} |`,
+    );
+  }
+  lines.push('');
+
+  lines.push('## Notable Examples');
+  lines.push('');
+  if (analysis.notableExamples.length === 0) {
+    lines.push('- None found for current strategy/results.');
+  } else {
+    for (const example of analysis.notableExamples) {
+      lines.push(`- ${example.questionId}: strategy "${example.strategy}" solved where models failed`);
+      lines.push(`  - Ground truth: ${example.groundTruth}`);
+      lines.push(`  - Ensemble answer: ${example.ensembleAnswer}`);
+      lines.push(`  - Prompt: ${example.prompt}`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Cost Analysis');
+  lines.push('');
+  lines.push('| Label | Total Tokens | Total Estimated Cost | Avg Cost/Question |');
+  lines.push('| --- | ---: | ---: | ---: |');
+  for (const row of analysis.costAnalysis) {
+    lines.push(
+      `| ${row.label} | ${row.totalTokens} | ${toUsd(row.totalEstimatedCostUsd)} | ${toUsd(row.averageCostPerQuestionUsd)} |`,
+    );
+  }
+  lines.push('');
+  lines.push(
+    '_Strategy costs are based on recorded model-response costs and may exclude extra summarizer-only overhead if not captured in the run schema._',
   );
   lines.push('');
-  lines.push('## Consensus Coverage');
-  lines.push('');
-
-  const strategyCounts = new Map<string, number>();
-  for (const run of runs) {
-    for (const strategy of Object.keys(run.consensus)) {
-      strategyCounts.set(strategy, (strategyCounts.get(strategy) ?? 0) + 1);
-    }
-  }
-
-  if (strategyCounts.size === 0) {
-    lines.push('- No consensus output found.');
-  } else {
-    for (const [strategy, count] of strategyCounts.entries()) {
-      lines.push(`- \`${strategy}\`: ${count} prompt(s)`);
-    }
-  }
 
   return `${lines.join('\n')}\n`;
 }

--- a/packages/eval/src/lib/statistics.test.ts
+++ b/packages/eval/src/lib/statistics.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { computeMcNemar, computePairedBootstrapDelta } from './statistics.js';
+
+describe('statistics', () => {
+  it('computes McNemar contingency counts and p-value', () => {
+    const result = computeMcNemar([
+      { modelCorrect: true, strategyCorrect: true },
+      { modelCorrect: true, strategyCorrect: false },
+      { modelCorrect: false, strategyCorrect: true },
+      { modelCorrect: false, strategyCorrect: false },
+      { modelCorrect: false, strategyCorrect: true },
+    ]);
+
+    expect(result).toMatchObject({
+      n11: 1,
+      n10: 1,
+      n01: 2,
+      n00: 1,
+    });
+    expect(result.pValue).toBeGreaterThanOrEqual(0);
+    expect(result.pValue).toBeLessThanOrEqual(1);
+  });
+
+  it('computes paired bootstrap delta and confidence interval', () => {
+    const random = vi.fn(() => 0.4);
+    const result = computePairedBootstrapDelta(
+      [
+        { modelCorrect: false, strategyCorrect: true },
+        { modelCorrect: false, strategyCorrect: true },
+        { modelCorrect: true, strategyCorrect: true },
+      ],
+      100,
+      random,
+    );
+
+    expect(result.meanDelta).toBeGreaterThan(0);
+    expect(result.ciLow).toBeLessThanOrEqual(result.meanDelta);
+    expect(result.ciHigh).toBeGreaterThanOrEqual(result.meanDelta);
+  });
+});

--- a/packages/eval/src/lib/statistics.ts
+++ b/packages/eval/src/lib/statistics.ts
@@ -1,0 +1,127 @@
+export interface BinaryPair {
+  modelCorrect: boolean;
+  strategyCorrect: boolean;
+}
+
+export interface McNemarResult {
+  n11: number;
+  n10: number;
+  n01: number;
+  n00: number;
+  chiSquared: number;
+  pValue: number;
+}
+
+export interface BootstrapDeltaResult {
+  meanDelta: number;
+  ciLow: number;
+  ciHigh: number;
+}
+
+function clamp01(value: number): number {
+  if (value < 0) {
+    return 0;
+  }
+  if (value > 1) {
+    return 1;
+  }
+  return value;
+}
+
+function erf(x: number): number {
+  const sign = x < 0 ? -1 : 1;
+  const absX = Math.abs(x);
+  const t = 1 / (1 + 0.3275911 * absX);
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const y =
+    1 -
+    (((((a5 * t + a4) * t + a3) * t + a2) * t + a1) *
+      t *
+      Math.exp(-absX * absX));
+  return sign * y;
+}
+
+function erfc(x: number): number {
+  return 1 - erf(x);
+}
+
+function quantile(sorted: number[], p: number): number {
+  if (sorted.length === 0) {
+    return 0;
+  }
+
+  const position = clamp01(p) * (sorted.length - 1);
+  const lowerIndex = Math.floor(position);
+  const upperIndex = Math.ceil(position);
+  if (lowerIndex === upperIndex) {
+    return sorted[lowerIndex];
+  }
+
+  const weight = position - lowerIndex;
+  return sorted[lowerIndex] * (1 - weight) + sorted[upperIndex] * weight;
+}
+
+export function computeMcNemar(pairs: BinaryPair[]): McNemarResult {
+  let n11 = 0;
+  let n10 = 0;
+  let n01 = 0;
+  let n00 = 0;
+
+  for (const pair of pairs) {
+    if (pair.modelCorrect && pair.strategyCorrect) {
+      n11 += 1;
+    } else if (pair.modelCorrect && !pair.strategyCorrect) {
+      n10 += 1;
+    } else if (!pair.modelCorrect && pair.strategyCorrect) {
+      n01 += 1;
+    } else {
+      n00 += 1;
+    }
+  }
+
+  const discordant = n10 + n01;
+  const chiSquared =
+    discordant === 0 ? 0 : ((Math.abs(n10 - n01) - 1) ** 2) / discordant;
+  const pValue = discordant === 0 ? 1 : erfc(Math.sqrt(chiSquared / 2));
+
+  return { n11, n10, n01, n00, chiSquared, pValue };
+}
+
+export function computePairedBootstrapDelta(
+  pairs: BinaryPair[],
+  iterations = 10_000,
+  random: () => number = Math.random,
+): BootstrapDeltaResult {
+  if (pairs.length === 0) {
+    return { meanDelta: 0, ciLow: 0, ciHigh: 0 };
+  }
+
+  const deltas: number[] = [];
+  for (let i = 0; i < iterations; i += 1) {
+    let modelCorrect = 0;
+    let strategyCorrect = 0;
+    for (let j = 0; j < pairs.length; j += 1) {
+      const sampleIndex = Math.floor(random() * pairs.length);
+      const sampled = pairs[sampleIndex];
+      modelCorrect += sampled.modelCorrect ? 1 : 0;
+      strategyCorrect += sampled.strategyCorrect ? 1 : 0;
+    }
+
+    const modelAccuracy = modelCorrect / pairs.length;
+    const strategyAccuracy = strategyCorrect / pairs.length;
+    deltas.push(strategyAccuracy - modelAccuracy);
+  }
+
+  deltas.sort((left, right) => left - right);
+  const meanDelta = deltas.reduce((sum, value) => sum + value, 0) / deltas.length;
+
+  return {
+    meanDelta,
+    ciLow: quantile(deltas, 0.025),
+    ciHigh: quantile(deltas, 0.975),
+  };
+}

--- a/packages/eval/src/types.ts
+++ b/packages/eval/src/types.ts
@@ -57,6 +57,8 @@ export interface PromptRunResult {
   questionId?: string;
   prompt: string;
   groundTruth?: string;
+  category?: string;
+  difficulty?: string;
   responses: ProviderResponse[];
   consensus: Partial<Record<StrategyName, string>>;
   evaluation?: PromptEvaluation;


### PR DESCRIPTION
## Summary
- implement benchmark analysis with model/strategy accuracy, McNemar paired tests, paired bootstrap confidence intervals, agreement calibration, category/difficulty breakdowns, notable examples, and cost analysis
- add structured analysis/report types plus helper modules for aggregation, comparisons, chart payloads, and statistics utilities
- update `analyze` CLI to generate markdown reports from analysis output and optionally emit chart-ready JSON files via `--charts`
- persist `category` and `difficulty` into benchmark/baseline run outputs so stratified analysis is available
- add unit tests covering statistical utilities, analysis generation, and report rendering

## Validation
- npm run typecheck --workspace @ensemble-ai/eval
- npm run test --workspace @ensemble-ai/eval
- pre-commit hook suite (component-library lint/tests, shared-utils tests, app lint/typecheck)

Closes #113
