### PR TITLE
fix(component-library): remove blue-over-green focus clash on configured API key input

### DIFF
--- a/packages/component-library/src/components/molecules/ApiKeyInput/ApiKeyInput.test.tsx
+++ b/packages/component-library/src/components/molecules/ApiKeyInput/ApiKeyInput.test.tsx
@@ -227,12 +227,28 @@ describe('ApiKeyInput', () => {
       expect(input).toHaveClass('bg-success/10');
     });
 
+    it('uses success focus ring when valid', () => {
+      const { container } = render(
+        <ApiKeyInput provider="openai" label="API Key" validationStatus="valid" value="sk-valid" />
+      );
+      const input = container.querySelector('input');
+      expect(input).toHaveClass('focus-visible:ring-success/40');
+    });
+
     it('uses destructive token for invalid border', () => {
       const { container } = render(
         <ApiKeyInput provider="openai" label="API Key" validationStatus="invalid" value="bad" error="Invalid" />
       );
       const input = container.querySelector('input');
       expect(input).toHaveClass('border-destructive');
+    });
+
+    it('uses destructive focus ring when invalid', () => {
+      const { container } = render(
+        <ApiKeyInput provider="openai" label="API Key" validationStatus="invalid" value="bad" error="Invalid" />
+      );
+      const input = container.querySelector('input');
+      expect(input).toHaveClass('focus-visible:ring-destructive/40');
     });
 
     it('uses success token for valid icon', () => {

--- a/packages/component-library/src/components/molecules/ApiKeyInput/ApiKeyInput.tsx
+++ b/packages/component-library/src/components/molecules/ApiKeyInput/ApiKeyInput.tsx
@@ -140,8 +140,10 @@ export const ApiKeyInput = React.forwardRef<HTMLInputElement, ApiKeyInputProps>(
             }
             className={cn(
               'pr-20',
-              validationStatus === 'valid' && 'border-success/50 bg-success/10',
-              validationStatus === 'invalid' && 'border-destructive',
+              validationStatus === 'valid' &&
+                'border-success/50 bg-success/10 focus-visible:border-success focus-visible:ring-success/40',
+              validationStatus === 'invalid' &&
+                'border-destructive focus-visible:border-destructive focus-visible:ring-destructive/40',
               disabled && 'disabled:opacity-50'
             )}
           />


### PR DESCRIPTION
## Summary
- update `ApiKeyInput` focus styles to use status-colored focus states
- when `validationStatus=valid`, focus ring and border now use success colors instead of default blue ring
- when `validationStatus=invalid`, focus ring and border now use destructive colors for consistency
- add tests to assert valid and invalid focus ring class behavior

## Validation
- npx vitest run src/components/molecules/ApiKeyInput/ApiKeyInput.test.tsx
- pre-commit hook suite (component-library lint/tests, shared-utils tests, app lint/typecheck)
