### PR TITLE
feat: add remove button to selected models in ensemble sidebar (#175)

### DIFF
--- a/packages/app/src/app/ensemble/page.tsx
+++ b/packages/app/src/app/ensemble/page.tsx
@@ -103,6 +103,7 @@ export default function EnsemblePage() {
             onDeletePreset={handleDeletePreset}
             onAddManualResponse={manualModal.openModal}
             manualResponses={viewManualResponses}
+            onRemoveModel={handleModelToggle}
             onClearAll={clearSelection}
             showQuickPresets={false}
             showSaveEnsemble={false}

--- a/packages/component-library/src/components/organisms/EnsembleSidebar/EnsembleSidebar.stories.tsx
+++ b/packages/component-library/src/components/organisms/EnsembleSidebar/EnsembleSidebar.stories.tsx
@@ -14,6 +14,7 @@ const meta = {
     onDeletePreset: () => { },
     onAddManualResponse: () => { },
     onClearAll: () => { },
+    onRemoveModel: (modelId: string) => { console.log('Remove model:', modelId); },
   },
 } satisfies Meta<typeof EnsembleSidebar>;
 

--- a/packages/component-library/src/components/organisms/EnsembleSidebar/EnsembleSidebar.test.tsx
+++ b/packages/component-library/src/components/organisms/EnsembleSidebar/EnsembleSidebar.test.tsx
@@ -682,6 +682,88 @@ describe('EnsembleSidebar', () => {
     });
   });
 
+  describe('remove model', () => {
+    it('renders remove buttons when onRemoveModel is provided', () => {
+      render(
+        <EnsembleSidebar
+          selectedModels={mockSelectedModels}
+          summarizerId="claude-3-opus"
+          presets={[]}
+          currentEnsembleName=""
+          onLoadPreset={vi.fn()}
+          onSavePreset={vi.fn()}
+          onDeletePreset={vi.fn()}
+          onAddManualResponse={vi.fn()}
+          onRemoveModel={vi.fn()}
+        />
+      );
+
+      expect(screen.getByTestId('remove-model-claude-3-opus')).toBeInTheDocument();
+      expect(screen.getByTestId('remove-model-gpt-4o')).toBeInTheDocument();
+    });
+
+    it('does not render remove buttons when onRemoveModel is not provided', () => {
+      render(
+        <EnsembleSidebar
+          selectedModels={mockSelectedModels}
+          summarizerId="claude-3-opus"
+          presets={[]}
+          currentEnsembleName=""
+          onLoadPreset={vi.fn()}
+          onSavePreset={vi.fn()}
+          onDeletePreset={vi.fn()}
+          onAddManualResponse={vi.fn()}
+        />
+      );
+
+      expect(screen.queryByTestId('remove-model-claude-3-opus')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('remove-model-gpt-4o')).not.toBeInTheDocument();
+    });
+
+    it('calls onRemoveModel with the correct model id when clicked', async () => {
+      const user = userEvent.setup();
+      const onRemoveModel = vi.fn();
+
+      render(
+        <EnsembleSidebar
+          selectedModels={mockSelectedModels}
+          summarizerId="claude-3-opus"
+          presets={[]}
+          currentEnsembleName=""
+          onLoadPreset={vi.fn()}
+          onSavePreset={vi.fn()}
+          onDeletePreset={vi.fn()}
+          onAddManualResponse={vi.fn()}
+          onRemoveModel={onRemoveModel}
+        />
+      );
+
+      await user.click(screen.getByTestId('remove-model-gpt-4o'));
+
+      expect(onRemoveModel).toHaveBeenCalledWith('gpt-4o');
+      expect(onRemoveModel).toHaveBeenCalledTimes(1);
+    });
+
+    it('provides accessible aria-label for remove buttons', () => {
+      render(
+        <EnsembleSidebar
+          selectedModels={mockSelectedModels}
+          summarizerId="claude-3-opus"
+          presets={[]}
+          currentEnsembleName=""
+          onLoadPreset={vi.fn()}
+          onSavePreset={vi.fn()}
+          onDeletePreset={vi.fn()}
+          onAddManualResponse={vi.fn()}
+          onRemoveModel={vi.fn()}
+        />
+      );
+
+      expect(screen.getByLabelText('Remove Claude 3 Opus')).toBeInTheDocument();
+      expect(screen.getByLabelText('Remove GPT-4o')).toBeInTheDocument();
+    });
+  });
+
   describe('layout', () => {
     it('uses Card component', () => {
       render(

--- a/packages/component-library/src/components/organisms/EnsembleSidebar/EnsembleSidebar.tsx
+++ b/packages/component-library/src/components/organisms/EnsembleSidebar/EnsembleSidebar.tsx
@@ -5,7 +5,7 @@ import { Button } from '../../atoms/Button';
 import { Badge } from '../../atoms/Badge';
 import { Heading } from '../../atoms/Heading';
 import { Text } from '../../atoms/Text';
-import { ArrowRight } from 'lucide-react';
+import { ArrowRight, X } from 'lucide-react';
 import { QuickPresetsSection } from './QuickPresetsSection';
 import { SaveEnsembleSection } from './SaveEnsembleSection';
 import { ManualResponsesSection } from './ManualResponsesSection';
@@ -45,6 +45,8 @@ export interface EnsembleSidebarProps {
   onAddManualResponse: () => void;
   /** Manual responses to display */
   manualResponses?: Array<{ id: string; label: string; response?: string }>;
+  /** Callback when a model is removed from the selection */
+  onRemoveModel?: (modelId: string) => void;
   /** Callback when clear all models is clicked */
   onClearAll?: () => void;
   /** Feature flag to show Quick Presets section (default: true) */
@@ -97,6 +99,7 @@ export const EnsembleSidebar = React.forwardRef<HTMLDivElement, EnsembleSidebarP
       onDeletePreset,
       onAddManualResponse,
       manualResponses = [],
+      onRemoveModel,
       onClearAll,
       showQuickPresets = true,
       showSaveEnsemble = true,
@@ -142,14 +145,27 @@ export const EnsembleSidebar = React.forwardRef<HTMLDivElement, EnsembleSidebarP
                 selectedModels.map((model) => (
                   <div key={model.id} className="flex items-center justify-between text-sm">
                     <span>{model.name}</span>
-                    {model.id === summarizerId && (
-                      <Badge
-                        variant="outline"
-                        className="text-xs bg-primary/10 text-primary border-primary/20"
-                      >
-                        {model.name}
-                      </Badge>
-                    )}
+                    <div className="flex items-center gap-1">
+                      {model.id === summarizerId && (
+                        <Badge
+                          variant="outline"
+                          className="text-xs bg-primary/10 text-primary border-primary/20"
+                        >
+                          {model.name}
+                        </Badge>
+                      )}
+                      {onRemoveModel && (
+                        <button
+                          type="button"
+                          className="ml-1 rounded-sm p-0.5 text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+                          onClick={() => onRemoveModel(model.id)}
+                          aria-label={t('organisms.ensembleSidebar.removeModel', { name: model.name })}
+                          data-testid={`remove-model-${model.id}`}
+                        >
+                          <X className="h-3.5 w-3.5" />
+                        </button>
+                      )}
+                    </div>
                   </div>
                 ))
               )}

--- a/packages/component-library/src/lib/i18n/locales/en.json
+++ b/packages/component-library/src/lib/i18n/locales/en.json
@@ -178,7 +178,8 @@
       "manualResponsesInfo": "Include custom responses to compare against live model outputs.",
       "addManualResponse": "Add Manual Response",
       "manualResponsesNote": "Add reference answers or benchmark outputs to compare against live model responses.",
-      "continueToPrompt": "Continue to Prompt"
+      "continueToPrompt": "Continue to Prompt",
+      "removeModel": "Remove {{name}}"
     },
     "manualResponseModal": {
       "title": "Manual Response",

--- a/packages/component-library/src/lib/i18n/locales/fr.json
+++ b/packages/component-library/src/lib/i18n/locales/fr.json
@@ -173,7 +173,8 @@
       "manualResponsesInfo": "Incluez des réponses personnalisées à comparer avec les résultats des modèles en direct.",
       "addManualResponse": "Ajouter une Réponse Manuelle",
       "manualResponsesNote": "Ajoutez des réponses de référence ou des résultats de référence à comparer avec les réponses des modèles en direct.",
-      "continueToPrompt": "Continuer vers l'Invite"
+      "continueToPrompt": "Continuer vers l'Invite",
+      "removeModel": "Retirer {{name}}"
     },
     "manualResponseModal": {
       "title": "Réponse Manuelle",


### PR DESCRIPTION
## Summary
- Adds an × button next to each selected model in the EnsembleSidebar component
- Button only renders when `onRemoveModel` callback is provided (backward compatible)
- Wired up in the ensemble page using the existing `handleModelToggle` handler
- Includes accessible `aria-label` with model name interpolation
- i18n support for English ("Remove {{name}}") and French ("Retirer {{name}}")

## Changes
- `EnsembleSidebar.tsx` — new `onRemoveModel` prop, `X` icon button per model
- `EnsembleSidebar.test.tsx` — 4 new tests (render, no-render, click callback, aria-label)
- `EnsembleSidebar.stories.tsx` — default args include `onRemoveModel`
- `ensemble/page.tsx` — passes `onRemoveModel={handleModelToggle}` to sidebar
- `en.json` / `fr.json` — new `removeModel` i18n key

Closes #175

## Test plan
- [x] All 59 EnsembleSidebar unit tests pass (4 new)
- [x] TypeScript compilation passes
- [x] ESLint passes
- [x] Production build succeeds
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)