### PR TITLE
fix: align sidebar header and summarizer badge pill (#178)

### DIFF
--- a/packages/component-library/src/components/organisms/EnsembleSidebar/EnsembleSidebar.test.tsx
+++ b/packages/component-library/src/components/organisms/EnsembleSidebar/EnsembleSidebar.test.tsx
@@ -137,9 +137,7 @@ describe('EnsembleSidebar', () => {
         />
       );
 
-      // Claude 3 Opus appears twice (model name + badge)
-      const claudeElements = screen.getAllByText('Claude 3 Opus');
-      expect(claudeElements.length).toBe(2);
+      expect(screen.getByText('Claude 3 Opus')).toBeInTheDocument();
       expect(screen.getByText('GPT-4o')).toBeInTheDocument();
     });
 
@@ -174,9 +172,9 @@ describe('EnsembleSidebar', () => {
         />
       );
 
-      // Badge should show summarizer model name
-      const badges = screen.getAllByText('Claude 3 Opus');
-      expect(badges.length).toBe(2); // model name + badge
+      // Badge should show "Summarizer" label on the designated model
+      const summarizerBadges = screen.getAllByText('Summarizer');
+      expect(summarizerBadges.length).toBeGreaterThanOrEqual(1);
     });
 
     it('shows empty state when no models selected', () => {

--- a/packages/component-library/src/components/organisms/EnsembleSidebar/EnsembleSidebar.tsx
+++ b/packages/component-library/src/components/organisms/EnsembleSidebar/EnsembleSidebar.tsx
@@ -124,7 +124,6 @@ export const EnsembleSidebar = React.forwardRef<HTMLDivElement, EnsembleSidebarP
                 {t('organisms.ensembleSidebar.selectedModels', { count: selectedModels.length })}
               </Heading>
               <div className="flex items-center gap-2">
-                {summarizerId && <Text as="span" variant="small" color="primary">{t('organisms.ensembleSidebar.summarizerLabel')}</Text>}
                 {selectedModels.length > 0 && onClearAll && (
                   <Button
                     variant="ghost"
@@ -151,7 +150,7 @@ export const EnsembleSidebar = React.forwardRef<HTMLDivElement, EnsembleSidebarP
                           variant="outline"
                           className="text-xs bg-primary/10 text-primary border-primary/20"
                         >
-                          {model.name}
+                          {t('organisms.ensembleSidebar.summarizerLabel')}
                         </Badge>
                       )}
                       {onRemoveModel && (


### PR DESCRIPTION
## Summary
- Removes the "Summarizer" label from the header row — it was squeezed between "Selected Models (N)" and "Clear All", causing visual clutter
- Changes the summarizer badge pill from redundantly showing the model name (e.g. "Gpt 5.1 2025 11 13") to a compact "Summarizer" label
- Header is now cleanly: heading on left, "Clear All" on right
- Model list rows are now evenly aligned — the badge is short and consistent

Closes #178

## Test plan
- [x] All 59 EnsembleSidebar unit tests pass (2 updated to match new behavior)
- [x] TypeScript compilation passes
- [x] ESLint passes
- [x] Pre-commit hooks pass
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)