### PR TITLE
fix(e2e): stabilize Start Over navigation in full workflow test

### DIFF
--- a/packages/e2e/tests/mock-mode/full-workflow-mock.spec.ts
+++ b/packages/e2e/tests/mock-mode/full-workflow-mock.spec.ts
@@ -221,24 +221,17 @@ test.describe('Full Workflow - Mock Mode', () => {
       // Wait for at least one response card to appear so the page is fully interactive
       await expect(page.locator('[data-testid^="response-card-"]').first()).toBeVisible({ timeout: 10000 });
 
-      const startOverButton = page.getByRole('button', { name: /start over/i }).first();
+      const startOverButton = page.getByRole('button', { name: /start over/i });
+      await expect(startOverButton).toHaveCount(1, { timeout: 10000 });
       await expect(startOverButton).toBeVisible({ timeout: 10000 });
       await expect(startOverButton).toBeEnabled({ timeout: 10000 });
-      let navigatedToConfig = false;
-      for (let attempt = 0; attempt < 3; attempt += 1) {
-        await startOverButton.click({ force: true, timeout: 5000 }).catch(async () => {
-          await startOverButton.evaluate((button: HTMLButtonElement) => button.click());
-        });
-        const reachedConfig = await page
-          .waitForURL('**/config', { timeout: 3000 })
-          .then(() => true)
-          .catch(() => false);
-        if (reachedConfig) {
-          navigatedToConfig = true;
-          break;
-        }
-      }
-      expect(navigatedToConfig).toBe(true);
+      await startOverButton.scrollIntoViewIfNeeded();
+
+      await Promise.all([
+        page.waitForURL('**/config', { timeout: 15000 }),
+        startOverButton.click({ timeout: 10000 }),
+      ]);
+
       await expect(page).toHaveURL(/\/config$/, { timeout: 10000 });
 
       // Verify we're back at config page


### PR DESCRIPTION
## Summary
- remove brittle force-click/evaluate retry loop from the full workflow mock E2E Start Over step
- use a deterministic Playwright pattern with a single click coordinated with `waitForURL('**/config')`
- assert a single Start Over button instance before clicking to avoid ambiguous targeting

## Validation
- `npm run test --workspace=packages/e2e -- --project=mock-mode tests/mock-mode/full-workflow-mock.spec.ts`
- `npm run test --workspace=packages/e2e -- --project=mock-mode`

Closes #176
