### PR TITLE
feat: add tooltips to progress step indicators

### DIFF
--- a/packages/component-library/src/components/molecules/ProgressSteps/ProgressSteps.stories.tsx
+++ b/packages/component-library/src/components/molecules/ProgressSteps/ProgressSteps.stories.tsx
@@ -90,3 +90,18 @@ export const ClickableCompletedSteps: Story = {
     );
   },
 };
+
+/** Hover over any step circle to see its descriptive tooltip. */
+export const WithTooltips: Story = {
+  args: {
+    currentStep: 'ensemble',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Each step displays a tooltip on hover describing what the step involves. Hover over the step circles to see the tooltips.',
+      },
+    },
+  },
+};

--- a/packages/component-library/src/components/molecules/ProgressSteps/__snapshots__/ProgressSteps.snapshot.test.tsx.snap
+++ b/packages/component-library/src/components/molecules/ProgressSteps/__snapshots__/ProgressSteps.snapshot.test.tsx.snap
@@ -11,6 +11,8 @@ exports[`ProgressSteps Snapshots > matches snapshot for config step 1`] = `
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_0_-tooltip-config"
+        class="group relative"
         data-active="true"
         data-completed="false"
         data-testid="progress-step-container-config"
@@ -23,15 +25,26 @@ exports[`ProgressSteps Snapshots > matches snapshot for config step 1`] = `
         >
           1
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-config"
+          id="_r_0_-tooltip-config"
+          role="tooltip"
+        >
+          Configure your API keys and select operating mode
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+        data-testid="progress-step-connector-0"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_0_-tooltip-ensemble"
+        class="group relative"
         data-active="false"
         data-completed="false"
         data-testid="progress-step-container-ensemble"
@@ -44,15 +57,26 @@ exports[`ProgressSteps Snapshots > matches snapshot for config step 1`] = `
         >
           2
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-ensemble"
+          id="_r_0_-tooltip-ensemble"
+          role="tooltip"
+        >
+          Select 2-6 AI models to compare
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+        data-testid="progress-step-connector-1"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_0_-tooltip-prompt"
+        class="group relative"
         data-active="false"
         data-completed="false"
         data-testid="progress-step-container-prompt"
@@ -65,15 +89,26 @@ exports[`ProgressSteps Snapshots > matches snapshot for config step 1`] = `
         >
           3
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-prompt"
+          id="_r_0_-tooltip-prompt"
+          role="tooltip"
+        >
+          Enter your question or prompt
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+        data-testid="progress-step-connector-2"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_0_-tooltip-review"
+        class="group relative"
         data-active="false"
         data-completed="false"
         data-testid="progress-step-container-review"
@@ -86,6 +121,14 @@ exports[`ProgressSteps Snapshots > matches snapshot for config step 1`] = `
         >
           4
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-review"
+          id="_r_0_-tooltip-review"
+          role="tooltip"
+        >
+          View and compare AI responses
+        </span>
       </div>
     </div>
   </div>
@@ -97,6 +140,7 @@ exports[`ProgressSteps Snapshots > matches snapshot for config step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-primary"
+        data-step-state="active"
       >
         Config
       </span>
@@ -109,6 +153,7 @@ exports[`ProgressSteps Snapshots > matches snapshot for config step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+        data-step-state="upcoming"
       >
         Ensemble
       </span>
@@ -121,6 +166,7 @@ exports[`ProgressSteps Snapshots > matches snapshot for config step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+        data-step-state="upcoming"
       >
         Prompt
       </span>
@@ -133,6 +179,7 @@ exports[`ProgressSteps Snapshots > matches snapshot for config step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+        data-step-state="upcoming"
       >
         Review
       </span>
@@ -152,6 +199,8 @@ exports[`ProgressSteps Snapshots > matches snapshot for ensemble step 1`] = `
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_1_-tooltip-config"
+        class="group relative"
         data-active="false"
         data-completed="true"
         data-testid="progress-step-container-config"
@@ -180,15 +229,26 @@ exports[`ProgressSteps Snapshots > matches snapshot for ensemble step 1`] = `
             />
           </svg>
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-config"
+          id="_r_1_-tooltip-config"
+          role="tooltip"
+        >
+          Configure your API keys and select operating mode
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-success"
+        data-testid="progress-step-connector-0"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_1_-tooltip-ensemble"
+        class="group relative"
         data-active="true"
         data-completed="false"
         data-testid="progress-step-container-ensemble"
@@ -201,15 +261,26 @@ exports[`ProgressSteps Snapshots > matches snapshot for ensemble step 1`] = `
         >
           2
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-ensemble"
+          id="_r_1_-tooltip-ensemble"
+          role="tooltip"
+        >
+          Select 2-6 AI models to compare
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+        data-testid="progress-step-connector-1"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_1_-tooltip-prompt"
+        class="group relative"
         data-active="false"
         data-completed="false"
         data-testid="progress-step-container-prompt"
@@ -222,15 +293,26 @@ exports[`ProgressSteps Snapshots > matches snapshot for ensemble step 1`] = `
         >
           3
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-prompt"
+          id="_r_1_-tooltip-prompt"
+          role="tooltip"
+        >
+          Enter your question or prompt
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+        data-testid="progress-step-connector-2"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_1_-tooltip-review"
+        class="group relative"
         data-active="false"
         data-completed="false"
         data-testid="progress-step-container-review"
@@ -243,6 +325,14 @@ exports[`ProgressSteps Snapshots > matches snapshot for ensemble step 1`] = `
         >
           4
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-review"
+          id="_r_1_-tooltip-review"
+          role="tooltip"
+        >
+          View and compare AI responses
+        </span>
       </div>
     </div>
   </div>
@@ -254,6 +344,7 @@ exports[`ProgressSteps Snapshots > matches snapshot for ensemble step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-success"
+        data-step-state="completed"
       >
         Config
       </span>
@@ -266,6 +357,7 @@ exports[`ProgressSteps Snapshots > matches snapshot for ensemble step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-primary"
+        data-step-state="active"
       >
         Ensemble
       </span>
@@ -278,6 +370,7 @@ exports[`ProgressSteps Snapshots > matches snapshot for ensemble step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+        data-step-state="upcoming"
       >
         Prompt
       </span>
@@ -290,6 +383,7 @@ exports[`ProgressSteps Snapshots > matches snapshot for ensemble step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+        data-step-state="upcoming"
       >
         Review
       </span>
@@ -309,6 +403,8 @@ exports[`ProgressSteps Snapshots > matches snapshot for prompt step 1`] = `
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_2_-tooltip-config"
+        class="group relative"
         data-active="false"
         data-completed="true"
         data-testid="progress-step-container-config"
@@ -337,15 +433,26 @@ exports[`ProgressSteps Snapshots > matches snapshot for prompt step 1`] = `
             />
           </svg>
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-config"
+          id="_r_2_-tooltip-config"
+          role="tooltip"
+        >
+          Configure your API keys and select operating mode
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-success"
+        data-testid="progress-step-connector-0"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_2_-tooltip-ensemble"
+        class="group relative"
         data-active="false"
         data-completed="true"
         data-testid="progress-step-container-ensemble"
@@ -374,15 +481,26 @@ exports[`ProgressSteps Snapshots > matches snapshot for prompt step 1`] = `
             />
           </svg>
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-ensemble"
+          id="_r_2_-tooltip-ensemble"
+          role="tooltip"
+        >
+          Select 2-6 AI models to compare
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-success"
+        data-testid="progress-step-connector-1"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_2_-tooltip-prompt"
+        class="group relative"
         data-active="true"
         data-completed="false"
         data-testid="progress-step-container-prompt"
@@ -395,15 +513,26 @@ exports[`ProgressSteps Snapshots > matches snapshot for prompt step 1`] = `
         >
           3
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-prompt"
+          id="_r_2_-tooltip-prompt"
+          role="tooltip"
+        >
+          Enter your question or prompt
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+        data-testid="progress-step-connector-2"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_2_-tooltip-review"
+        class="group relative"
         data-active="false"
         data-completed="false"
         data-testid="progress-step-container-review"
@@ -416,6 +545,14 @@ exports[`ProgressSteps Snapshots > matches snapshot for prompt step 1`] = `
         >
           4
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-review"
+          id="_r_2_-tooltip-review"
+          role="tooltip"
+        >
+          View and compare AI responses
+        </span>
       </div>
     </div>
   </div>
@@ -427,6 +564,7 @@ exports[`ProgressSteps Snapshots > matches snapshot for prompt step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-success"
+        data-step-state="completed"
       >
         Config
       </span>
@@ -439,6 +577,7 @@ exports[`ProgressSteps Snapshots > matches snapshot for prompt step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-success"
+        data-step-state="completed"
       >
         Ensemble
       </span>
@@ -451,6 +590,7 @@ exports[`ProgressSteps Snapshots > matches snapshot for prompt step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-primary"
+        data-step-state="active"
       >
         Prompt
       </span>
@@ -463,6 +603,7 @@ exports[`ProgressSteps Snapshots > matches snapshot for prompt step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+        data-step-state="upcoming"
       >
         Review
       </span>
@@ -482,6 +623,8 @@ exports[`ProgressSteps Snapshots > matches snapshot for review step 1`] = `
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_3_-tooltip-config"
+        class="group relative"
         data-active="false"
         data-completed="true"
         data-testid="progress-step-container-config"
@@ -510,15 +653,26 @@ exports[`ProgressSteps Snapshots > matches snapshot for review step 1`] = `
             />
           </svg>
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-config"
+          id="_r_3_-tooltip-config"
+          role="tooltip"
+        >
+          Configure your API keys and select operating mode
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-success"
+        data-testid="progress-step-connector-0"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_3_-tooltip-ensemble"
+        class="group relative"
         data-active="false"
         data-completed="true"
         data-testid="progress-step-container-ensemble"
@@ -547,15 +701,26 @@ exports[`ProgressSteps Snapshots > matches snapshot for review step 1`] = `
             />
           </svg>
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-ensemble"
+          id="_r_3_-tooltip-ensemble"
+          role="tooltip"
+        >
+          Select 2-6 AI models to compare
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-success"
+        data-testid="progress-step-connector-1"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_3_-tooltip-prompt"
+        class="group relative"
         data-active="false"
         data-completed="true"
         data-testid="progress-step-container-prompt"
@@ -584,15 +749,26 @@ exports[`ProgressSteps Snapshots > matches snapshot for review step 1`] = `
             />
           </svg>
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-prompt"
+          id="_r_3_-tooltip-prompt"
+          role="tooltip"
+        >
+          Enter your question or prompt
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-success"
+        data-testid="progress-step-connector-2"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_3_-tooltip-review"
+        class="group relative"
         data-active="true"
         data-completed="false"
         data-testid="progress-step-container-review"
@@ -605,6 +781,14 @@ exports[`ProgressSteps Snapshots > matches snapshot for review step 1`] = `
         >
           4
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-review"
+          id="_r_3_-tooltip-review"
+          role="tooltip"
+        >
+          View and compare AI responses
+        </span>
       </div>
     </div>
   </div>
@@ -616,6 +800,7 @@ exports[`ProgressSteps Snapshots > matches snapshot for review step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-success"
+        data-step-state="completed"
       >
         Config
       </span>
@@ -628,6 +813,7 @@ exports[`ProgressSteps Snapshots > matches snapshot for review step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-success"
+        data-step-state="completed"
       >
         Ensemble
       </span>
@@ -640,6 +826,7 @@ exports[`ProgressSteps Snapshots > matches snapshot for review step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-success"
+        data-step-state="completed"
       >
         Prompt
       </span>
@@ -652,6 +839,7 @@ exports[`ProgressSteps Snapshots > matches snapshot for review step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-primary"
+        data-step-state="active"
       >
         Review
       </span>

--- a/packages/component-library/src/components/molecules/ProgressSteps/__snapshots__/ProgressSteps.test.tsx.snap
+++ b/packages/component-library/src/components/molecules/ProgressSteps/__snapshots__/ProgressSteps.test.tsx.snap
@@ -11,6 +11,8 @@ exports[`ProgressSteps > snapshots > matches snapshot for config step 1`] = `
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_e_-tooltip-config"
+        class="group relative"
         data-active="true"
         data-completed="false"
         data-testid="progress-step-container-config"
@@ -23,15 +25,26 @@ exports[`ProgressSteps > snapshots > matches snapshot for config step 1`] = `
         >
           1
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-config"
+          id="_r_e_-tooltip-config"
+          role="tooltip"
+        >
+          Configure your API keys and select operating mode
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+        data-testid="progress-step-connector-0"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_e_-tooltip-ensemble"
+        class="group relative"
         data-active="false"
         data-completed="false"
         data-testid="progress-step-container-ensemble"
@@ -44,15 +57,26 @@ exports[`ProgressSteps > snapshots > matches snapshot for config step 1`] = `
         >
           2
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-ensemble"
+          id="_r_e_-tooltip-ensemble"
+          role="tooltip"
+        >
+          Select 2-6 AI models to compare
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+        data-testid="progress-step-connector-1"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_e_-tooltip-prompt"
+        class="group relative"
         data-active="false"
         data-completed="false"
         data-testid="progress-step-container-prompt"
@@ -65,15 +89,26 @@ exports[`ProgressSteps > snapshots > matches snapshot for config step 1`] = `
         >
           3
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-prompt"
+          id="_r_e_-tooltip-prompt"
+          role="tooltip"
+        >
+          Enter your question or prompt
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+        data-testid="progress-step-connector-2"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_e_-tooltip-review"
+        class="group relative"
         data-active="false"
         data-completed="false"
         data-testid="progress-step-container-review"
@@ -86,6 +121,14 @@ exports[`ProgressSteps > snapshots > matches snapshot for config step 1`] = `
         >
           4
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-review"
+          id="_r_e_-tooltip-review"
+          role="tooltip"
+        >
+          View and compare AI responses
+        </span>
       </div>
     </div>
   </div>
@@ -97,6 +140,7 @@ exports[`ProgressSteps > snapshots > matches snapshot for config step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-primary"
+        data-step-state="active"
       >
         Config
       </span>
@@ -109,6 +153,7 @@ exports[`ProgressSteps > snapshots > matches snapshot for config step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+        data-step-state="upcoming"
       >
         Ensemble
       </span>
@@ -121,6 +166,7 @@ exports[`ProgressSteps > snapshots > matches snapshot for config step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+        data-step-state="upcoming"
       >
         Prompt
       </span>
@@ -133,6 +179,7 @@ exports[`ProgressSteps > snapshots > matches snapshot for config step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+        data-step-state="upcoming"
       >
         Review
       </span>
@@ -152,6 +199,8 @@ exports[`ProgressSteps > snapshots > matches snapshot for ensemble step 1`] = `
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_f_-tooltip-config"
+        class="group relative"
         data-active="false"
         data-completed="true"
         data-testid="progress-step-container-config"
@@ -180,15 +229,26 @@ exports[`ProgressSteps > snapshots > matches snapshot for ensemble step 1`] = `
             />
           </svg>
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-config"
+          id="_r_f_-tooltip-config"
+          role="tooltip"
+        >
+          Configure your API keys and select operating mode
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-success"
+        data-testid="progress-step-connector-0"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_f_-tooltip-ensemble"
+        class="group relative"
         data-active="true"
         data-completed="false"
         data-testid="progress-step-container-ensemble"
@@ -201,15 +261,26 @@ exports[`ProgressSteps > snapshots > matches snapshot for ensemble step 1`] = `
         >
           2
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-ensemble"
+          id="_r_f_-tooltip-ensemble"
+          role="tooltip"
+        >
+          Select 2-6 AI models to compare
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+        data-testid="progress-step-connector-1"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_f_-tooltip-prompt"
+        class="group relative"
         data-active="false"
         data-completed="false"
         data-testid="progress-step-container-prompt"
@@ -222,15 +293,26 @@ exports[`ProgressSteps > snapshots > matches snapshot for ensemble step 1`] = `
         >
           3
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-prompt"
+          id="_r_f_-tooltip-prompt"
+          role="tooltip"
+        >
+          Enter your question or prompt
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+        data-testid="progress-step-connector-2"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_f_-tooltip-review"
+        class="group relative"
         data-active="false"
         data-completed="false"
         data-testid="progress-step-container-review"
@@ -243,6 +325,14 @@ exports[`ProgressSteps > snapshots > matches snapshot for ensemble step 1`] = `
         >
           4
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-review"
+          id="_r_f_-tooltip-review"
+          role="tooltip"
+        >
+          View and compare AI responses
+        </span>
       </div>
     </div>
   </div>
@@ -254,6 +344,7 @@ exports[`ProgressSteps > snapshots > matches snapshot for ensemble step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-success"
+        data-step-state="completed"
       >
         Config
       </span>
@@ -266,6 +357,7 @@ exports[`ProgressSteps > snapshots > matches snapshot for ensemble step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-primary"
+        data-step-state="active"
       >
         Ensemble
       </span>
@@ -278,6 +370,7 @@ exports[`ProgressSteps > snapshots > matches snapshot for ensemble step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+        data-step-state="upcoming"
       >
         Prompt
       </span>
@@ -290,6 +383,7 @@ exports[`ProgressSteps > snapshots > matches snapshot for ensemble step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+        data-step-state="upcoming"
       >
         Review
       </span>
@@ -309,6 +403,8 @@ exports[`ProgressSteps > snapshots > matches snapshot for prompt step 1`] = `
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_g_-tooltip-config"
+        class="group relative"
         data-active="false"
         data-completed="true"
         data-testid="progress-step-container-config"
@@ -337,15 +433,26 @@ exports[`ProgressSteps > snapshots > matches snapshot for prompt step 1`] = `
             />
           </svg>
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-config"
+          id="_r_g_-tooltip-config"
+          role="tooltip"
+        >
+          Configure your API keys and select operating mode
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-success"
+        data-testid="progress-step-connector-0"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_g_-tooltip-ensemble"
+        class="group relative"
         data-active="false"
         data-completed="true"
         data-testid="progress-step-container-ensemble"
@@ -374,15 +481,26 @@ exports[`ProgressSteps > snapshots > matches snapshot for prompt step 1`] = `
             />
           </svg>
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-ensemble"
+          id="_r_g_-tooltip-ensemble"
+          role="tooltip"
+        >
+          Select 2-6 AI models to compare
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-success"
+        data-testid="progress-step-connector-1"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_g_-tooltip-prompt"
+        class="group relative"
         data-active="true"
         data-completed="false"
         data-testid="progress-step-container-prompt"
@@ -395,15 +513,26 @@ exports[`ProgressSteps > snapshots > matches snapshot for prompt step 1`] = `
         >
           3
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-prompt"
+          id="_r_g_-tooltip-prompt"
+          role="tooltip"
+        >
+          Enter your question or prompt
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-muted"
+        data-testid="progress-step-connector-2"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_g_-tooltip-review"
+        class="group relative"
         data-active="false"
         data-completed="false"
         data-testid="progress-step-container-review"
@@ -416,6 +545,14 @@ exports[`ProgressSteps > snapshots > matches snapshot for prompt step 1`] = `
         >
           4
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-review"
+          id="_r_g_-tooltip-review"
+          role="tooltip"
+        >
+          View and compare AI responses
+        </span>
       </div>
     </div>
   </div>
@@ -427,6 +564,7 @@ exports[`ProgressSteps > snapshots > matches snapshot for prompt step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-success"
+        data-step-state="completed"
       >
         Config
       </span>
@@ -439,6 +577,7 @@ exports[`ProgressSteps > snapshots > matches snapshot for prompt step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-success"
+        data-step-state="completed"
       >
         Ensemble
       </span>
@@ -451,6 +590,7 @@ exports[`ProgressSteps > snapshots > matches snapshot for prompt step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-primary"
+        data-step-state="active"
       >
         Prompt
       </span>
@@ -463,6 +603,7 @@ exports[`ProgressSteps > snapshots > matches snapshot for prompt step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-muted-foreground"
+        data-step-state="upcoming"
       >
         Review
       </span>
@@ -482,6 +623,8 @@ exports[`ProgressSteps > snapshots > matches snapshot for review step 1`] = `
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_h_-tooltip-config"
+        class="group relative"
         data-active="false"
         data-completed="true"
         data-testid="progress-step-container-config"
@@ -510,15 +653,26 @@ exports[`ProgressSteps > snapshots > matches snapshot for review step 1`] = `
             />
           </svg>
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-config"
+          id="_r_h_-tooltip-config"
+          role="tooltip"
+        >
+          Configure your API keys and select operating mode
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-success"
+        data-testid="progress-step-connector-0"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_h_-tooltip-ensemble"
+        class="group relative"
         data-active="false"
         data-completed="true"
         data-testid="progress-step-container-ensemble"
@@ -547,15 +701,26 @@ exports[`ProgressSteps > snapshots > matches snapshot for review step 1`] = `
             />
           </svg>
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-ensemble"
+          id="_r_h_-tooltip-ensemble"
+          role="tooltip"
+        >
+          Select 2-6 AI models to compare
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-success"
+        data-testid="progress-step-connector-1"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_h_-tooltip-prompt"
+        class="group relative"
         data-active="false"
         data-completed="true"
         data-testid="progress-step-container-prompt"
@@ -584,15 +749,26 @@ exports[`ProgressSteps > snapshots > matches snapshot for review step 1`] = `
             />
           </svg>
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-prompt"
+          id="_r_h_-tooltip-prompt"
+          role="tooltip"
+        >
+          Enter your question or prompt
+        </span>
       </div>
       <div
         class="w-16 h-0.5 mx-4 transition-colors bg-success"
+        data-testid="progress-step-connector-2"
       />
     </div>
     <div
       class="flex items-center"
     >
       <div
+        aria-describedby="_r_h_-tooltip-review"
+        class="group relative"
         data-active="true"
         data-completed="false"
         data-testid="progress-step-container-review"
@@ -605,6 +781,14 @@ exports[`ProgressSteps > snapshots > matches snapshot for review step 1`] = `
         >
           4
         </div>
+        <span
+          class="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md opacity-0 transition-opacity group-hover:opacity-100"
+          data-testid="progress-step-tooltip-review"
+          id="_r_h_-tooltip-review"
+          role="tooltip"
+        >
+          View and compare AI responses
+        </span>
       </div>
     </div>
   </div>
@@ -616,6 +800,7 @@ exports[`ProgressSteps > snapshots > matches snapshot for review step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-success"
+        data-step-state="completed"
       >
         Config
       </span>
@@ -628,6 +813,7 @@ exports[`ProgressSteps > snapshots > matches snapshot for review step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-success"
+        data-step-state="completed"
       >
         Ensemble
       </span>
@@ -640,6 +826,7 @@ exports[`ProgressSteps > snapshots > matches snapshot for review step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-success"
+        data-step-state="completed"
       >
         Prompt
       </span>
@@ -652,6 +839,7 @@ exports[`ProgressSteps > snapshots > matches snapshot for review step 1`] = `
     >
       <span
         class="inline-block w-12 text-center text-sm font-medium transition-colors text-primary"
+        data-step-state="active"
       >
         Review
       </span>

--- a/packages/component-library/src/lib/i18n/locales/en.json
+++ b/packages/component-library/src/lib/i18n/locales/en.json
@@ -17,7 +17,13 @@
       "config": "Config",
       "ensemble": "Ensemble",
       "prompt": "Prompt",
-      "review": "Review"
+      "review": "Review",
+      "tooltips": {
+        "config": "Configure your API keys and select operating mode",
+        "ensemble": "Select 2-6 AI models to compare",
+        "prompt": "Enter your question or prompt",
+        "review": "View and compare AI responses"
+      }
     }
   },
   "atoms": {

--- a/packages/component-library/src/lib/i18n/locales/fr.json
+++ b/packages/component-library/src/lib/i18n/locales/fr.json
@@ -17,7 +17,13 @@
       "config": "Config",
       "ensemble": "Ensemble",
       "prompt": "Invite",
-      "review": "Révision"
+      "review": "Révision",
+      "tooltips": {
+        "config": "Configurez vos clés API et sélectionnez le mode de fonctionnement",
+        "ensemble": "Sélectionnez 2 à 6 modèles IA à comparer",
+        "prompt": "Entrez votre question ou votre requête",
+        "review": "Consultez et comparez les réponses IA"
+      }
     }
   },
   "atoms": {


### PR DESCRIPTION
## Summary
- Add descriptive tooltips to each step in the ProgressSteps component
- Tooltips explain what each workflow step involves on hover
- Support EN and FR translations via i18n keys
- Accessible via `aria-describedby` linking step containers to tooltip elements with `role="tooltip"`

Closes #143

## Test plan
- [x] Tooltip text renders correctly for each step
- [x] Tooltips have `role="tooltip"` for semantic HTML
- [x] `aria-describedby` correctly links containers/buttons to tooltips
- [x] EN and FR translations work
- [x] All 32 ProgressSteps tests pass
- [x] All 1091 component library tests pass
- [x] Lint passes
- [x] App typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)