### PR TITLE
fix: auto-hide API keys on navigation and after 10s timeout

### DIFF
--- a/packages/app/src/app/config/hooks/useApiKeyAutoHide.ts
+++ b/packages/app/src/app/config/hooks/useApiKeyAutoHide.ts
@@ -1,0 +1,56 @@
+import { useRef, useCallback, useEffect } from 'react';
+import { useStore } from '~/store';
+import type { Provider } from '@/components/molecules/ApiKeyInput';
+
+const AUTO_HIDE_DELAY_MS = 10_000;
+const PROVIDERS: Provider[] = ['openai', 'anthropic', 'google', 'xai'];
+
+/**
+ * Auto-hides revealed API keys after a period of inactivity and
+ * on page navigation (mount/unmount).
+ */
+export function useApiKeyAutoHide() {
+    const apiKeys = useStore((state) => state.apiKeys);
+    const hideAllApiKeys = useStore((state) => state.hideAllApiKeys);
+    const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+    const clearTimer = useCallback(() => {
+        if (timerRef.current) {
+            clearTimeout(timerRef.current);
+            timerRef.current = null;
+        }
+    }, []);
+
+    const resetAutoHideTimer = useCallback(() => {
+        clearTimer();
+        const hasVisible = PROVIDERS.some((p) => apiKeys[p]?.visible);
+        if (hasVisible) {
+            timerRef.current = setTimeout(() => {
+                hideAllApiKeys();
+            }, AUTO_HIDE_DELAY_MS);
+        }
+    }, [apiKeys, clearTimer, hideAllApiKeys]);
+
+    // Hide all on mount (returning to page) and unmount (navigating away)
+    useEffect(() => {
+        hideAllApiKeys();
+        return () => {
+            hideAllApiKeys();
+        };
+    }, [hideAllApiKeys]);
+
+    // Start/reset the auto-hide timer whenever visibility changes
+    const anyKeyVisible = PROVIDERS.some((p) => apiKeys[p]?.visible);
+    useEffect(() => {
+        if (!anyKeyVisible) {
+            clearTimer();
+            return;
+        }
+        timerRef.current = setTimeout(() => {
+            hideAllApiKeys();
+        }, AUTO_HIDE_DELAY_MS);
+        return clearTimer;
+    }, [anyKeyVisible, clearTimer, hideAllApiKeys]);
+
+    return { resetAutoHideTimer };
+}

--- a/packages/app/src/app/config/hooks/useConfigPage.ts
+++ b/packages/app/src/app/config/hooks/useConfigPage.ts
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useStore } from '~/store';
 import { useHasHydrated } from '~/hooks/useHasHydrated';
 import { useStepNavigation } from '~/hooks/useStepNavigation';
+import { useApiKeyAutoHide } from './useApiKeyAutoHide';
 import type { OperatingMode } from '~/store/slices/modeSlice';
 import type { Provider, ValidationStatus } from '@/components/molecules/ApiKeyInput';
 import { validateApiKey, createDebouncedValidator } from '~/lib/validation';
@@ -40,6 +41,7 @@ export function useConfigPage() {
         google: null,
         xai: null,
     });
+    const { resetAutoHideTimer } = useApiKeyAutoHide();
     const [webCryptoSupported, setWebCryptoSupported] = useState(true);
 
     const handleSelectFreeMode = () => {
@@ -119,6 +121,7 @@ export function useConfigPage() {
             );
         });
         debouncedValidate(provider, value, mode, handleValidationStatusChange);
+        resetAutoHideTimer();
     };
 
     const handleToggleShow = (provider: Provider) => {

--- a/packages/app/src/store/__tests__/apiKeySlice.test.ts
+++ b/packages/app/src/store/__tests__/apiKeySlice.test.ts
@@ -135,6 +135,24 @@ describe('apiKeySlice', () => {
     expect(decryptMock).toHaveBeenCalledTimes(1);
   });
 
+  it('hides all visible API keys', async () => {
+    await store.getState().setApiKey('openai', 'sk-key1');
+    await store.getState().setApiKey('anthropic', 'sk-key2');
+    store.getState().toggleApiKeyVisibility('openai');
+    store.getState().toggleApiKeyVisibility('anthropic');
+    expect(store.getState().apiKeys.openai?.visible).toBe(true);
+    expect(store.getState().apiKeys.anthropic?.visible).toBe(true);
+
+    store.getState().hideAllApiKeys();
+    expect(store.getState().apiKeys.openai?.visible).toBe(false);
+    expect(store.getState().apiKeys.anthropic?.visible).toBe(false);
+  });
+
+  it('hideAllApiKeys is a no-op when no keys are visible', () => {
+    store.getState().hideAllApiKeys();
+    expect(store.getState().apiKeys.openai).toBeNull();
+  });
+
   it('handles decryption failures by clearing encrypted values', async () => {
     decryptMock.mockRejectedValueOnce(new Error('bad decrypt'));
     store.setState({

--- a/packages/app/src/store/index.ts
+++ b/packages/app/src/store/index.ts
@@ -69,7 +69,7 @@ const sanitizeStateForPersist = (state: StoreState): StoreState => {
         [provider]: {
           encrypted: entry.encrypted,
           key: '',
-          visible: entry.visible,
+          visible: false,
           status: entry.status,
         },
       };

--- a/packages/app/src/store/slices/apiKeySlice.ts
+++ b/packages/app/src/store/slices/apiKeySlice.ts
@@ -30,6 +30,7 @@ export interface ApiKeySlice {
 
   setApiKey: (provider: ProviderType, key: string) => Promise<void>;
   toggleApiKeyVisibility: (provider: ProviderType) => void;
+  hideAllApiKeys: () => void;
   getApiKey: (provider: ProviderType) => string | null;
   clearApiKeys: () => void;
   initializeEncryption: () => Promise<void>;
@@ -168,6 +169,20 @@ export const createApiKeySlice: StateCreator<ApiKeySlice> = (set, get) => ({
           },
         },
       };
+    });
+  },
+
+  hideAllApiKeys: () => {
+    set((state) => {
+      const providers: ProviderType[] = ['openai', 'anthropic', 'google', 'xai'];
+      const updatedKeys = { ...state.apiKeys };
+      for (const provider of providers) {
+        const entry = updatedKeys[provider];
+        if (entry?.visible) {
+          updatedKeys[provider] = { ...entry, visible: false };
+        }
+      }
+      return { apiKeys: updatedKeys };
     });
   },
 


### PR DESCRIPTION
## Summary
- Adds `hideAllApiKeys()` store action to reset all visible flags at once
- Extracts `useApiKeyAutoHide` hook that hides keys on page mount/unmount and starts a 10-second auto-hide timer when any key is revealed
- Resets the timer on key input interaction so active editing doesn't hide keys prematurely
- Stops persisting the `visible` flag to localStorage (always starts hidden)

## Test plan
- [x] Unit tests for `hideAllApiKeys` store action (2 new tests)
- [x] All 137 app tests pass
- [x] All 1070 component library tests pass
- [x] Lint + typecheck clean
- [x] FTA complexity score under threshold
- [ ] All CI checks pass

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)