### PR TITLE
feat(eval): add temperature parameter to AIProvider.streamResponse (#209)

### DIFF
--- a/packages/eval/src/commands/benchmark.ts
+++ b/packages/eval/src/commands/benchmark.ts
@@ -22,6 +22,7 @@ interface BenchmarkCommandOptions {
   mode: EvalMode;
   summarizer?: string;
   requestDelayMs?: string;
+  temperature?: string;
 }
 
 export function createBenchmarkCommand(): Command {
@@ -52,6 +53,10 @@ export function createBenchmarkCommand(): Command {
       'Optional delay in milliseconds between starting model calls.',
       '0',
     )
+    .option(
+      '--temperature <value>',
+      'Temperature for model responses (e.g. 0 for deterministic).',
+    )
     .option('--mode <mode>', 'Provider mode to use (mock or free)', 'mock')
     .action(async (dataset: string, options: BenchmarkCommandOptions) => {
       const models = parseModelSpecs(options.models);
@@ -68,6 +73,12 @@ export function createBenchmarkCommand(): Command {
       const requestDelayMs = Number.parseInt(options.requestDelayMs ?? '0', 10);
       if (!Number.isInteger(requestDelayMs) || requestDelayMs < 0) {
         throw new Error(`Invalid request delay "${options.requestDelayMs}".`);
+      }
+      const temperature = options.temperature !== undefined
+        ? Number.parseFloat(options.temperature)
+        : undefined;
+      if (temperature !== undefined && Number.isNaN(temperature)) {
+        throw new Error(`Invalid temperature "${options.temperature}".`);
       }
 
       const { datasetName, questions } = await loadBenchmarkQuestions(dataset, {
@@ -113,6 +124,7 @@ export function createBenchmarkCommand(): Command {
         evaluator,
         summarizer,
         requestDelayMs,
+        temperature,
       });
       await runner.run({
         questions,

--- a/packages/eval/src/lib/benchmarkRunner.ts
+++ b/packages/eval/src/lib/benchmarkRunner.ts
@@ -27,6 +27,7 @@ interface BenchmarkRunnerConfig {
   evaluator: EvaluatorLike | null;
   summarizer: ModelSpec | null;
   requestDelayMs?: number;
+  temperature?: number;
 }
 
 interface RunBenchmarkOptions {
@@ -54,6 +55,7 @@ export class BenchmarkRunner {
     this.summarizer = config.summarizer;
     this.ensembleRunner = new EnsembleRunner(config.registry, config.mode, {
       requestDelayMs: config.requestDelayMs,
+      temperature: config.temperature,
     });
   }
 

--- a/packages/shared-utils/src/providers/clients/anthropic/FreeAnthropicClient.ts
+++ b/packages/shared-utils/src/providers/clients/anthropic/FreeAnthropicClient.ts
@@ -61,6 +61,9 @@ export class FreeAnthropicClient extends BaseFreeClient {
         max_tokens: 1024, // Default limit
         messages: [{ role: 'user', content: options.prompt }],
         stream: true,
+        ...(options.streamOptions?.temperature !== undefined && {
+          temperature: options.streamOptions.temperature,
+        }),
       });
 
       for await (const event of stream) {

--- a/packages/shared-utils/src/providers/clients/base/BaseFreeClient.ts
+++ b/packages/shared-utils/src/providers/clients/base/BaseFreeClient.ts
@@ -1,4 +1,4 @@
-import type { AIProvider, ProviderName, ValidationResult } from '../../types';
+import type { AIProvider, ProviderName, StreamResponseOptions, ValidationResult } from '../../types';
 import { MockProviderClient } from '../mock/MockProviderClient';
 
 export interface StreamHandlers {
@@ -11,6 +11,7 @@ export interface StreamOptions extends StreamHandlers {
   apiKey: string;
   prompt: string;
   model: string;
+  streamOptions?: StreamResponseOptions;
 }
 
 /**
@@ -42,6 +43,7 @@ export abstract class BaseFreeClient implements AIProvider {
     onChunk: (chunk: string) => void,
     onComplete: (fullResponse: string, responseTime: number, tokenCount?: number) => void,
     onError: (error: Error) => void,
+    options?: StreamResponseOptions,
   ): Promise<void> {
     const apiKey = this.resolveApiKey();
 
@@ -76,6 +78,7 @@ export abstract class BaseFreeClient implements AIProvider {
           onChunk,
           onComplete,
           onError,
+          streamOptions: options,
         }),
         timeoutPromise,
       ]);

--- a/packages/shared-utils/src/providers/clients/google/FreeGoogleClient.ts
+++ b/packages/shared-utils/src/providers/clients/google/FreeGoogleClient.ts
@@ -71,7 +71,12 @@ export class FreeGoogleClient extends BaseFreeClient {
 
     try {
       const genAI = this.createClient(options.apiKey);
-      const model = genAI.getGenerativeModel({ model: options.model });
+      const model = genAI.getGenerativeModel({
+        model: options.model,
+        ...(options.streamOptions?.temperature !== undefined && {
+          generationConfig: { temperature: options.streamOptions.temperature },
+        }),
+      });
 
       const result = await model.generateContentStream(options.prompt);
 

--- a/packages/shared-utils/src/providers/clients/mock/MockProviderClient.ts
+++ b/packages/shared-utils/src/providers/clients/mock/MockProviderClient.ts
@@ -5,7 +5,7 @@
  * Generates lorem ipsum text with streaming behaviour that mimics real APIs.
  */
 
-import type { AIProvider, ModelMetadata, ValidationResult, ProviderName } from '../../types.js';
+import type { AIProvider, ModelMetadata, StreamResponseOptions, ValidationResult, ProviderName } from '../../types.js';
 
 export interface MockClientConfig {
   enableErrors?: boolean;
@@ -55,6 +55,7 @@ export class MockProviderClient implements AIProvider {
     onChunk: (chunk: string) => void,
     onComplete: (fullResponse: string, responseTime: number, tokenCount?: number) => void,
     onError: (error: Error) => void,
+    _options?: StreamResponseOptions,
   ): Promise<void> {
     if (this.config.enableErrors && Math.random() < this.config.errorProbability) {
       onError(new Error('Rate limit exceeded. Please try again in 60 seconds.'));

--- a/packages/shared-utils/src/providers/clients/openai/FreeOpenAIClient.ts
+++ b/packages/shared-utils/src/providers/clients/openai/FreeOpenAIClient.ts
@@ -65,6 +65,12 @@ export class FreeOpenAIClient extends BaseFreeClient {
       stream: true,
       messages: [{ role: 'user', content: options.prompt }],
       stream_options: { include_usage: true },
+      ...(options.streamOptions?.temperature !== undefined && {
+        temperature: options.streamOptions.temperature,
+      }),
+      ...(options.streamOptions?.seed !== undefined && {
+        seed: options.streamOptions.seed,
+      }),
     });
 
     for await (const chunk of stream as AsyncIterable<{

--- a/packages/shared-utils/src/providers/clients/xai/FreeXAIClient.ts
+++ b/packages/shared-utils/src/providers/clients/xai/FreeXAIClient.ts
@@ -74,6 +74,12 @@ export class FreeXAIClient extends BaseFreeClient {
         stream: true,
         messages: [{ role: 'user', content: options.prompt }],
         stream_options: { include_usage: true },
+        ...(options.streamOptions?.temperature !== undefined && {
+          temperature: options.streamOptions.temperature,
+        }),
+        ...(options.streamOptions?.seed !== undefined && {
+          seed: options.streamOptions.seed,
+        }),
       });
 
       for await (const chunk of stream as AsyncIterable<{

--- a/packages/shared-utils/src/providers/types.ts
+++ b/packages/shared-utils/src/providers/types.ts
@@ -16,6 +16,11 @@ export interface ValidationResult {
   error?: string;
 }
 
+export interface StreamResponseOptions {
+  temperature?: number;
+  seed?: number;
+}
+
 export interface AIProvider {
   streamResponse(
     prompt: string,
@@ -27,6 +32,7 @@ export interface AIProvider {
       tokenCount?: number,
     ) => void,
     onError: (error: Error) => void,
+    options?: StreamResponseOptions,
   ): Promise<void>;
 
   generateEmbeddings(text: string): Promise<number[]>;


### PR DESCRIPTION
## Summary
- Adds `StreamResponseOptions` type with `temperature` and `seed` fields to the `AIProvider` interface as an optional 6th parameter
- Threads the options through `BaseFreeClient`, all free provider clients (OpenAI, Anthropic, Google, XAI), `MockProviderClient`, `EnsembleRunner`, `BenchmarkRunner`, and both CLI commands (`benchmark`, `baseline`)
- Enables deterministic responses (`temperature: 0`) for eval runs so variance comes from ensemble strategy rather than random sampling

Closes #209

## Test plan
- [x] All existing tests pass unchanged (backwards compatible — 6th param is optional)
- [x] New tests verify `streamResponse` receives options with temperature
- [x] New test verifies no options passed when temperature is not set
- [x] `shared-utils` typecheck passes
- [x] `eval` typecheck passes
- [x] `app` lint + typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)