### PR TITLE
feat(eval): add consensus evaluation to BenchmarkRunner (#210)

### DIFF
--- a/packages/eval/src/lib/analysis.test.ts
+++ b/packages/eval/src/lib/analysis.test.ts
@@ -112,4 +112,50 @@ describe('analyzeBenchmarkRuns', () => {
     expect(analysis.charts.costVsAccuracyFrontier.length).toBeGreaterThanOrEqual(3);
     expect(analysis.charts.modelDiversityHeatmap.models).toHaveLength(2);
   });
+
+  it('uses pre-computed consensusEvaluation when present', () => {
+    const run: PromptRunResult = {
+      questionId: 'q1',
+      prompt: 'one',
+      groundTruth: '1',
+      category: 'math',
+      difficulty: 'easy',
+      responses: [
+        {
+          provider: 'openai',
+          model: 'gpt-4o',
+          content: '1',
+          responseTimeMs: 10,
+          tokenCount: 100,
+          estimatedCostUsd: 0.001,
+        },
+      ],
+      consensus: {
+        standard: 'summarized answer',
+      },
+      evaluation: {
+        evaluator: 'generative',
+        groundTruth: '1',
+        accuracy: 1,
+        results: {
+          'openai:gpt-4o': { predicted: '1', expected: '1', correct: true },
+        },
+      },
+      consensusEvaluation: {
+        evaluator: 'generative',
+        groundTruth: '1',
+        results: {
+          standard: { predicted: 'summarized answer', expected: '1', correct: true },
+        },
+      },
+    };
+
+    const analysis = analyzeBenchmarkRuns([run], { bootstrapIterations: 50 });
+
+    expect(analysis.strategyAccuracy[0]).toMatchObject({
+      label: 'standard',
+      correct: 1,
+      total: 1,
+    });
+  });
 });

--- a/packages/eval/src/lib/analysisAggregates.ts
+++ b/packages/eval/src/lib/analysisAggregates.ts
@@ -1,4 +1,4 @@
-import type { PromptRunResult } from '../types.js';
+import type { PromptRunResult, StrategyName } from '../types.js';
 import {
   collectModelResults,
   evaluateConsensusAnswer,
@@ -129,7 +129,8 @@ export function collectAnalysisAggregates(runs: PromptRunResult[]): AnalysisAggr
     const strategyResults: QuestionSummary['strategyResults'] = {};
     const runCost = responseCostTotals(run);
     for (const [strategy, answer] of Object.entries(run.consensus)) {
-      const evaluated = evaluateConsensusAnswer(
+      const preComputed = run.consensusEvaluation?.results?.[strategy as StrategyName];
+      const evaluated = preComputed ?? evaluateConsensusAnswer(
         run.evaluation?.evaluator,
         answer,
         groundTruth,

--- a/packages/eval/src/lib/benchmarkRunner.ts
+++ b/packages/eval/src/lib/benchmarkRunner.ts
@@ -1,6 +1,6 @@
 import type { ProviderRegistry } from '@ensemble-ai/shared-utils/providers';
 import { generateConsensus } from './consensus.js';
-import { evaluateResponses, type EvaluatorLike } from './evaluation.js';
+import { evaluateConsensusStrategies, evaluateResponses, type EvaluatorLike } from './evaluation.js';
 import { writeJsonFile } from './io.js';
 import { EnsembleRunner } from './ensembleRunner.js';
 import type {
@@ -107,6 +107,13 @@ export class BenchmarkRunner {
         question.prompt,
       );
 
+      const consensusEvaluation = await evaluateConsensusStrategies(
+        this.evaluator,
+        consensus,
+        question.groundTruth,
+        question.prompt,
+      );
+
       const run: PromptRunResult = {
         questionId: question.id,
         prompt: question.prompt,
@@ -116,6 +123,7 @@ export class BenchmarkRunner {
         responses,
         consensus,
         evaluation,
+        consensusEvaluation,
       };
       output.runs.push(run);
       output.updatedAt = new Date().toISOString();

--- a/packages/eval/src/types.ts
+++ b/packages/eval/src/types.ts
@@ -53,6 +53,12 @@ export interface SelfConsistencyResult {
   correct: boolean | null;
 }
 
+export interface ConsensusEvaluation {
+  evaluator: PromptEvaluation['evaluator'];
+  groundTruth: string;
+  results: Partial<Record<StrategyName, EvaluationResult>>;
+}
+
 export interface PromptRunResult {
   questionId?: string;
   prompt: string;
@@ -62,6 +68,7 @@ export interface PromptRunResult {
   responses: ProviderResponse[];
   consensus: Partial<Record<StrategyName, string>>;
   evaluation?: PromptEvaluation;
+  consensusEvaluation?: ConsensusEvaluation;
   selfConsistency?: SelfConsistencyResult;
 }
 


### PR DESCRIPTION
## Summary
- Adds `ConsensusEvaluation` type and `evaluateConsensusStrategies()` function that evaluates consensus strategy outputs against ground truth during benchmark runs
- Previously consensus outputs were generated but **never evaluated** — we couldn't measure if the ensemble beats individual models
- Updates `analysisAggregates` to prefer pre-computed `consensusEvaluation` data with backward-compatible fallback to `evaluateConsensusAnswer()` for older data files

Closes #210

## Test plan
- [x] New tests for `evaluateConsensusStrategies` (returns undefined when evaluator/groundTruth missing, evaluates each strategy, skips empty entries)
- [x] New test verifying `consensusEvaluation` is populated in BenchmarkRunner output
- [x] New test verifying analysis uses pre-computed `consensusEvaluation` data
- [x] All 46 existing + new tests pass
- [x] `eval` typecheck passes
- [x] `app` lint + typecheck unaffected (no shared-utils changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)