### PR TITLE
feat(eval): implement tier configuration for CI and post-merge (#218)

### DIFF
--- a/packages/eval/src/index.ts
+++ b/packages/eval/src/index.ts
@@ -11,3 +11,4 @@ export * from './lib/selfConsistency.js';
 export * from './lib/analysis.js';
 export * from './lib/statistics.js';
 export * from './lib/regressionTypes.js';
+export * from './lib/tierConfig.js';

--- a/packages/eval/src/lib/tierConfig.test.ts
+++ b/packages/eval/src/lib/tierConfig.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TierConfig } from './regressionTypes.js';
+import { CI_TIER_CONFIG, POST_MERGE_TIER_CONFIG, getTierConfig } from './tierConfig.js';
+
+describe('CI_TIER_CONFIG', () => {
+  it('has name "ci"', () => {
+    expect(CI_TIER_CONFIG.name).toBe('ci');
+  });
+
+  it('includes 30 questions across 3 datasets (10 GSM8K + 10 TruthfulQA + 10 GPQA)', () => {
+    expect(CI_TIER_CONFIG.datasets).toEqual([
+      { name: 'gsm8k', sampleSize: 10 },
+      { name: 'truthfulqa', sampleSize: 10 },
+      { name: 'gpqa', sampleSize: 10 },
+    ]);
+  });
+
+  it('uses 3 cheap models', () => {
+    expect(CI_TIER_CONFIG.models).toHaveLength(3);
+
+    const modelIds = CI_TIER_CONFIG.models.map((m) => m.model);
+    expect(modelIds).toContain('gpt-4o-mini');
+    expect(modelIds).toContain('claude-3-haiku-20240307');
+    expect(modelIds).toContain('gemini-1.5-flash');
+  });
+
+  it('assigns correct providers to models', () => {
+    const byModel = Object.fromEntries(CI_TIER_CONFIG.models.map((m) => [m.model, m.provider]));
+    expect(byModel['gpt-4o-mini']).toBe('openai');
+    expect(byModel['claude-3-haiku-20240307']).toBe('anthropic');
+    expect(byModel['gemini-1.5-flash']).toBe('google');
+  });
+
+  it('evaluates all 3 strategies', () => {
+    expect(CI_TIER_CONFIG.strategies).toEqual(['standard', 'elo', 'majority']);
+  });
+
+  it('runs 3 times for median stability', () => {
+    expect(CI_TIER_CONFIG.runs).toBe(3);
+  });
+
+  it('has 200ms request stagger', () => {
+    expect(CI_TIER_CONFIG.requestDelayMs).toBe(200);
+  });
+
+  it('uses p < 0.10 significance threshold', () => {
+    expect(CI_TIER_CONFIG.significanceThreshold).toBe(0.1);
+  });
+
+  it('uses gpt-4o-mini as summarizer', () => {
+    expect(CI_TIER_CONFIG.summarizer).toEqual({ provider: 'openai', model: 'gpt-4o-mini' });
+  });
+
+  it('satisfies the TierConfig type', () => {
+    const config: TierConfig = CI_TIER_CONFIG;
+    expect(config).toBeDefined();
+  });
+});
+
+describe('POST_MERGE_TIER_CONFIG', () => {
+  it('has name "post-merge"', () => {
+    expect(POST_MERGE_TIER_CONFIG.name).toBe('post-merge');
+  });
+
+  it('includes 250 questions across 3 datasets (100 GSM8K + 100 TruthfulQA + 50 GPQA)', () => {
+    expect(POST_MERGE_TIER_CONFIG.datasets).toEqual([
+      { name: 'gsm8k', sampleSize: 100 },
+      { name: 'truthfulqa', sampleSize: 100 },
+      { name: 'gpqa', sampleSize: 50 },
+    ]);
+  });
+
+  it('uses 4 full models', () => {
+    expect(POST_MERGE_TIER_CONFIG.models).toHaveLength(4);
+
+    const modelIds = POST_MERGE_TIER_CONFIG.models.map((m) => m.model);
+    expect(modelIds).toContain('gpt-4o');
+    expect(modelIds).toContain('claude-3.5-sonnet');
+    expect(modelIds).toContain('gemini-1.5-pro');
+    expect(modelIds).toContain('grok-2');
+  });
+
+  it('assigns correct providers to models', () => {
+    const byModel = Object.fromEntries(
+      POST_MERGE_TIER_CONFIG.models.map((m) => [m.model, m.provider]),
+    );
+    expect(byModel['gpt-4o']).toBe('openai');
+    expect(byModel['claude-3.5-sonnet']).toBe('anthropic');
+    expect(byModel['gemini-1.5-pro']).toBe('google');
+    expect(byModel['grok-2']).toBe('xai');
+  });
+
+  it('evaluates all 3 strategies', () => {
+    expect(POST_MERGE_TIER_CONFIG.strategies).toEqual(['standard', 'elo', 'majority']);
+  });
+
+  it('runs once (deterministic with temperature=0)', () => {
+    expect(POST_MERGE_TIER_CONFIG.runs).toBe(1);
+  });
+
+  it('has 500ms request stagger', () => {
+    expect(POST_MERGE_TIER_CONFIG.requestDelayMs).toBe(500);
+  });
+
+  it('uses p < 0.05 significance threshold', () => {
+    expect(POST_MERGE_TIER_CONFIG.significanceThreshold).toBe(0.05);
+  });
+
+  it('uses gpt-4o as summarizer', () => {
+    expect(POST_MERGE_TIER_CONFIG.summarizer).toEqual({ provider: 'openai', model: 'gpt-4o' });
+  });
+
+  it('satisfies the TierConfig type', () => {
+    const config: TierConfig = POST_MERGE_TIER_CONFIG;
+    expect(config).toBeDefined();
+  });
+});
+
+describe('getTierConfig', () => {
+  it('returns CI config for "ci" tier', () => {
+    expect(getTierConfig('ci')).toBe(CI_TIER_CONFIG);
+  });
+
+  it('returns post-merge config for "post-merge" tier', () => {
+    expect(getTierConfig('post-merge')).toBe(POST_MERGE_TIER_CONFIG);
+  });
+
+  it('throws on invalid tier name', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => getTierConfig('invalid' as any)).toThrow('Unknown tier: "invalid"');
+  });
+});

--- a/packages/eval/src/lib/tierConfig.ts
+++ b/packages/eval/src/lib/tierConfig.ts
@@ -1,0 +1,76 @@
+import type { TierConfig } from './regressionTypes.js';
+
+/**
+ * CI tier configuration for fast PR gate checks.
+ *
+ * Uses 30 questions across 3 datasets with cheap models to provide quick
+ * regression feedback. Targets under 5 minutes and under $0.50 per run.
+ *
+ * - 3 runs per evaluation (median for stability)
+ * - p < 0.10 significance threshold (Fisher's exact test)
+ */
+export const CI_TIER_CONFIG: TierConfig = {
+  name: 'ci',
+  datasets: [
+    { name: 'gsm8k', sampleSize: 10 },
+    { name: 'truthfulqa', sampleSize: 10 },
+    { name: 'gpqa', sampleSize: 10 },
+  ],
+  models: [
+    { provider: 'openai', model: 'gpt-4o-mini' },
+    { provider: 'anthropic', model: 'claude-3-haiku-20240307' },
+    { provider: 'google', model: 'gemini-1.5-flash' },
+  ],
+  strategies: ['standard', 'elo', 'majority'],
+  runs: 3,
+  requestDelayMs: 200,
+  significanceThreshold: 0.1,
+  summarizer: { provider: 'openai', model: 'gpt-4o-mini' },
+};
+
+/**
+ * Post-merge tier configuration for thorough nightly evaluation runs.
+ *
+ * Uses 250 questions across 3 datasets with full-capability models for
+ * comprehensive regression detection. Targets approximately $2-3 per run.
+ *
+ * - 1 run (deterministic with temperature=0)
+ * - p < 0.05 significance threshold (McNemar's test + Holm-Bonferroni correction)
+ */
+export const POST_MERGE_TIER_CONFIG: TierConfig = {
+  name: 'post-merge',
+  datasets: [
+    { name: 'gsm8k', sampleSize: 100 },
+    { name: 'truthfulqa', sampleSize: 100 },
+    { name: 'gpqa', sampleSize: 50 },
+  ],
+  models: [
+    { provider: 'openai', model: 'gpt-4o' },
+    { provider: 'anthropic', model: 'claude-3.5-sonnet' },
+    { provider: 'google', model: 'gemini-1.5-pro' },
+    { provider: 'xai', model: 'grok-2' },
+  ],
+  strategies: ['standard', 'elo', 'majority'],
+  runs: 1,
+  requestDelayMs: 500,
+  significanceThreshold: 0.05,
+  summarizer: { provider: 'openai', model: 'gpt-4o' },
+};
+
+/**
+ * Returns the tier configuration for the given evaluation tier.
+ *
+ * @param tier - The evaluation tier: `'ci'` for PR gate checks, `'post-merge'` for nightly runs.
+ * @returns The corresponding {@link TierConfig}.
+ * @throws {Error} If the tier name is not recognized.
+ */
+export function getTierConfig(tier: 'ci' | 'post-merge'): TierConfig {
+  switch (tier) {
+    case 'ci':
+      return CI_TIER_CONFIG;
+    case 'post-merge':
+      return POST_MERGE_TIER_CONFIG;
+    default:
+      throw new Error(`Unknown tier: "${tier as string}"`);
+  }
+}


### PR DESCRIPTION
## Summary
- Define CI tier config (30 questions, 3 cheap models, p<0.10)
- Define post-merge tier config (250 questions, 4 full models, p<0.05)
- Add `getTierConfig` helper function
- Export from package index

Closes #218

## Test plan
- [x] CI tier config values verified (models, question counts, strategies, runs, delay, threshold, summarizer)
- [x] Post-merge tier config values verified (models, question counts, strategies, runs, delay, threshold, summarizer)
- [x] `getTierConfig` helper returns correct config for both tiers
- [x] `getTierConfig` throws on invalid tier name
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)