### PR TITLE
feat: define EnsembleResult Zod schemas and JSON contracts (#187)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26512,7 +26512,8 @@
         "form-data-encoder": "^1.7.2",
         "formdata-node": "^4.4.1",
         "node-fetch": "^2.7.0",
-        "openai": "^4.68.4"
+        "openai": "^4.68.4",
+        "zod": "^3.24.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",

--- a/packages/shared-utils/package.json
+++ b/packages/shared-utils/package.json
@@ -67,6 +67,7 @@
     "form-data-encoder": "^1.7.2",
     "formdata-node": "^4.4.1",
     "node-fetch": "^2.7.0",
-    "openai": "^4.68.4"
+    "openai": "^4.68.4",
+    "zod": "^3.24.2"
   }
 }

--- a/packages/shared-utils/src/consensus/__tests__/schemas.test.ts
+++ b/packages/shared-utils/src/consensus/__tests__/schemas.test.ts
@@ -1,0 +1,562 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  EnsembleMetadataSchema,
+  ModelResponseReferenceSchema,
+  StandardConsensusResultSchema,
+  EloRankingResultSchema,
+  MajorityVotingResultSchema,
+  LLMCouncilResultSchema,
+  EnsembleResultSchema,
+  parseEnsembleResult,
+} from '../schemas';
+
+import {
+  isStandardResult,
+  isEloResult,
+  isMajorityResult,
+  isCouncilResult,
+} from '../types';
+
+import type { EnsembleResult } from '../types';
+
+// ---------------------------------------------------------------------------
+// Shared test fixtures
+// ---------------------------------------------------------------------------
+
+const baseMetadata = {
+  timestamp: '2026-01-15T10:30:00.000Z',
+  prompt: 'What is the capital of France?',
+  modelIds: ['model-a', 'model-b', 'model-c'],
+  summarizerModel: 'model-a',
+};
+
+const sampleResponse = {
+  modelId: 'model-a',
+  provider: 'openai',
+  model: 'gpt-4o',
+  modelName: 'GPT-4o',
+  content: 'The capital of France is Paris.',
+  responseTime: 1234,
+  tokenCount: 42,
+};
+
+const sampleResponseB = {
+  ...sampleResponse,
+  modelId: 'model-b',
+  provider: 'anthropic',
+  model: 'claude-3-opus',
+  modelName: 'Claude 3 Opus',
+};
+
+// ---------------------------------------------------------------------------
+// EnsembleMetadataSchema
+// ---------------------------------------------------------------------------
+
+describe('EnsembleMetadataSchema', () => {
+  it('parses valid metadata', () => {
+    const result = EnsembleMetadataSchema.safeParse({
+      ...baseMetadata,
+      schemaVersion: '1.0.0',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('defaults schemaVersion to 1.0.0 when omitted', () => {
+    const result = EnsembleMetadataSchema.safeParse(baseMetadata);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.schemaVersion).toBe('1.0.0');
+    }
+  });
+
+  it('rejects missing required fields', () => {
+    const result = EnsembleMetadataSchema.safeParse({ timestamp: '2026-01-15T10:30:00.000Z' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid timestamp format', () => {
+    const result = EnsembleMetadataSchema.safeParse({
+      ...baseMetadata,
+      timestamp: 'not-a-date',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ModelResponseReferenceSchema
+// ---------------------------------------------------------------------------
+
+describe('ModelResponseReferenceSchema', () => {
+  it('parses a valid response reference', () => {
+    const result = ModelResponseReferenceSchema.safeParse(sampleResponse);
+    expect(result.success).toBe(true);
+  });
+
+  it('allows optional tokenCount to be omitted', () => {
+    const { tokenCount: _, ...withoutTokenCount } = sampleResponse;
+    void _;
+    const result = ModelResponseReferenceSchema.safeParse(withoutTokenCount);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing required fields', () => {
+    const result = ModelResponseReferenceSchema.safeParse({ modelId: 'x' });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StandardConsensusResultSchema
+// ---------------------------------------------------------------------------
+
+describe('StandardConsensusResultSchema', () => {
+  const validStandard = {
+    ...baseMetadata,
+    type: 'standard' as const,
+    synthesis: 'Paris is the capital of France.',
+    responses: [sampleResponse, sampleResponseB],
+  };
+
+  it('parses a valid standard result', () => {
+    const result = StandardConsensusResultSchema.safeParse(validStandard);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses with optional sourceHighlights', () => {
+    const result = StandardConsensusResultSchema.safeParse({
+      ...validStandard,
+      sourceHighlights: [{ modelId: 'model-a', highlight: 'Paris' }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects wrong type discriminator', () => {
+    const result = StandardConsensusResultSchema.safeParse({
+      ...validStandard,
+      type: 'elo',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing synthesis', () => {
+    const { synthesis: _, ...noSynthesis } = validStandard;
+    void _;
+    const result = StandardConsensusResultSchema.safeParse(noSynthesis);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EloRankingResultSchema
+// ---------------------------------------------------------------------------
+
+describe('EloRankingResultSchema', () => {
+  const validElo = {
+    ...baseMetadata,
+    type: 'elo' as const,
+    pairwiseComparisons: [
+      { modelA: 'model-a', modelB: 'model-b', winner: 'model-a', reasoning: 'More complete answer.' },
+    ],
+    rankings: [
+      { modelId: 'model-a', score: 1232, rank: 1 },
+      { modelId: 'model-b', score: 1168, rank: 2 },
+    ],
+    topN: 2,
+    synthesis: 'Paris is the capital of France.',
+    responses: [sampleResponse, sampleResponseB],
+  };
+
+  it('parses a valid elo result', () => {
+    const result = EloRankingResultSchema.safeParse(validElo);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses with optional tournamentBracket', () => {
+    const result = EloRankingResultSchema.safeParse({
+      ...validElo,
+      tournamentBracket: { rounds: [] },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing rankings', () => {
+    const { rankings: _, ...noRankings } = validElo;
+    void _;
+    const result = EloRankingResultSchema.safeParse(noRankings);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing pairwiseComparisons', () => {
+    const { pairwiseComparisons: _, ...noPairwise } = validElo;
+    void _;
+    const result = EloRankingResultSchema.safeParse(noPairwise);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MajorityVotingResultSchema
+// ---------------------------------------------------------------------------
+
+describe('MajorityVotingResultSchema', () => {
+  const validMajority = {
+    ...baseMetadata,
+    type: 'majority' as const,
+    alignmentScores: [
+      { modelId: 'model-a', score: 92 },
+      { modelId: 'model-b', score: 85 },
+    ],
+    majorityModelId: 'model-a',
+    agreementBreakdown: { unanimous: 0.7, majority: 0.2, split: 0.1 },
+    synthesis: 'Paris is the capital of France.',
+    responses: [sampleResponse, sampleResponseB],
+  };
+
+  it('parses a valid majority result', () => {
+    const result = MajorityVotingResultSchema.safeParse(validMajority);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing majorityModelId', () => {
+    const { majorityModelId: _, ...noMajority } = validMajority;
+    void _;
+    const result = MajorityVotingResultSchema.safeParse(noMajority);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing agreementBreakdown', () => {
+    const { agreementBreakdown: _, ...noBreakdown } = validMajority;
+    void _;
+    const result = MajorityVotingResultSchema.safeParse(noBreakdown);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid agreementBreakdown shape', () => {
+    const result = MajorityVotingResultSchema.safeParse({
+      ...validMajority,
+      agreementBreakdown: { unanimous: 'high' },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LLMCouncilResultSchema
+// ---------------------------------------------------------------------------
+
+describe('LLMCouncilResultSchema', () => {
+  const validCouncil = {
+    ...baseMetadata,
+    type: 'council' as const,
+    deliberationRounds: [
+      {
+        round: 1,
+        statements: [
+          { modelId: 'model-a', statement: 'I believe Paris.', position: 'agree' },
+          { modelId: 'model-b', statement: 'I concur.', position: 'agree' },
+        ],
+      },
+    ],
+    finalVotes: [
+      { modelId: 'model-a', vote: 'Paris', reasoning: 'Widely accepted fact.' },
+      { modelId: 'model-b', vote: 'Paris', reasoning: 'Historical evidence.' },
+    ],
+    consensusMetrics: { agreementScore: 0.95, convergenceRate: 0.9, rounds: 1 },
+    synthesis: 'Paris is the capital of France.',
+    responses: [sampleResponse, sampleResponseB],
+  };
+
+  it('parses a valid council result', () => {
+    const result = LLMCouncilResultSchema.safeParse(validCouncil);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing deliberationRounds', () => {
+    const { deliberationRounds: _, ...noRounds } = validCouncil;
+    void _;
+    const result = LLMCouncilResultSchema.safeParse(noRounds);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing consensusMetrics', () => {
+    const { consensusMetrics: _, ...noMetrics } = validCouncil;
+    void _;
+    const result = LLMCouncilResultSchema.safeParse(noMetrics);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid consensusMetrics shape', () => {
+    const result = LLMCouncilResultSchema.safeParse({
+      ...validCouncil,
+      consensusMetrics: { agreementScore: 'high' },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EnsembleResultSchema (discriminated union)
+// ---------------------------------------------------------------------------
+
+describe('EnsembleResultSchema', () => {
+  const validStandard = {
+    ...baseMetadata,
+    type: 'standard' as const,
+    synthesis: 'Paris.',
+    responses: [sampleResponse],
+  };
+
+  const validElo = {
+    ...baseMetadata,
+    type: 'elo' as const,
+    pairwiseComparisons: [
+      { modelA: 'model-a', modelB: 'model-b', winner: 'model-a', reasoning: 'Better.' },
+    ],
+    rankings: [{ modelId: 'model-a', score: 1232, rank: 1 }],
+    topN: 1,
+    synthesis: 'Paris.',
+    responses: [sampleResponse],
+  };
+
+  const validMajority = {
+    ...baseMetadata,
+    type: 'majority' as const,
+    alignmentScores: [{ modelId: 'model-a', score: 92 }],
+    majorityModelId: 'model-a',
+    agreementBreakdown: { unanimous: 1, majority: 0, split: 0 },
+    synthesis: 'Paris.',
+    responses: [sampleResponse],
+  };
+
+  const validCouncil = {
+    ...baseMetadata,
+    type: 'council' as const,
+    deliberationRounds: [
+      { round: 1, statements: [{ modelId: 'model-a', statement: 'Paris.', position: 'agree' }] },
+    ],
+    finalVotes: [{ modelId: 'model-a', vote: 'Paris', reasoning: 'Fact.' }],
+    consensusMetrics: { agreementScore: 1, convergenceRate: 1, rounds: 1 },
+    synthesis: 'Paris.',
+    responses: [sampleResponse],
+  };
+
+  it('parses standard type', () => {
+    expect(EnsembleResultSchema.safeParse(validStandard).success).toBe(true);
+  });
+
+  it('parses elo type', () => {
+    expect(EnsembleResultSchema.safeParse(validElo).success).toBe(true);
+  });
+
+  it('parses majority type', () => {
+    expect(EnsembleResultSchema.safeParse(validMajority).success).toBe(true);
+  });
+
+  it('parses council type', () => {
+    expect(EnsembleResultSchema.safeParse(validCouncil).success).toBe(true);
+  });
+
+  it('rejects unknown type discriminator', () => {
+    const result = EnsembleResultSchema.safeParse({
+      ...validStandard,
+      type: 'unknown',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing type field', () => {
+    const { type: _, ...noType } = validStandard;
+    void _;
+    const result = EnsembleResultSchema.safeParse(noType);
+    expect(result.success).toBe(false);
+  });
+
+  it('defaults schemaVersion when omitted via union', () => {
+    const result = EnsembleResultSchema.safeParse(validStandard);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.schemaVersion).toBe('1.0.0');
+    }
+  });
+
+  it('preserves unknown fields via passthrough (forward compatibility)', () => {
+    const withExtra = { ...validStandard, futureField: 'hello', anotherOne: 42 };
+    const result = EnsembleResultSchema.safeParse(withExtra);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as Record<string, unknown>;
+      expect(data['futureField']).toBe('hello');
+      expect(data['anotherOne']).toBe(42);
+    }
+  });
+
+  it('preserves unknown fields on nested response references', () => {
+    const responseWithExtra = { ...sampleResponse, newMetric: 'fast' };
+    const result = EnsembleResultSchema.safeParse({
+      ...validStandard,
+      responses: [responseWithExtra],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const resp = result.data.responses[0] as Record<string, unknown>;
+      expect(resp['newMetric']).toBe('fast');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseEnsembleResult helper
+// ---------------------------------------------------------------------------
+
+describe('parseEnsembleResult', () => {
+  const validStandard = {
+    ...baseMetadata,
+    type: 'standard',
+    synthesis: 'Paris.',
+    responses: [sampleResponse],
+  };
+
+  it('returns success for valid JSON', () => {
+    const result = parseEnsembleResult(validStandard);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.type).toBe('standard');
+    }
+  });
+
+  it('returns failure for invalid JSON', () => {
+    const result = parseEnsembleResult({ type: 'standard' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns failure for null input', () => {
+    const result = parseEnsembleResult(null);
+    expect(result.success).toBe(false);
+  });
+
+  it('returns failure for non-object input', () => {
+    const result = parseEnsembleResult('not an object');
+    expect(result.success).toBe(false);
+  });
+
+  it('provides descriptive error messages', () => {
+    const result = parseEnsembleResult({ type: 'standard', timestamp: 123 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+describe('Type guards', () => {
+  const standardResult: EnsembleResult = {
+    ...baseMetadata,
+    schemaVersion: '1.0.0',
+    type: 'standard',
+    synthesis: 'Paris.',
+    responses: [sampleResponse],
+  };
+
+  const eloResult: EnsembleResult = {
+    ...baseMetadata,
+    schemaVersion: '1.0.0',
+    type: 'elo',
+    pairwiseComparisons: [
+      { modelA: 'model-a', modelB: 'model-b', winner: 'model-a', reasoning: 'Better.' },
+    ],
+    rankings: [{ modelId: 'model-a', score: 1232, rank: 1 }],
+    topN: 1,
+    synthesis: 'Paris.',
+    responses: [sampleResponse],
+  };
+
+  const majorityResult: EnsembleResult = {
+    ...baseMetadata,
+    schemaVersion: '1.0.0',
+    type: 'majority',
+    alignmentScores: [{ modelId: 'model-a', score: 92 }],
+    majorityModelId: 'model-a',
+    agreementBreakdown: { unanimous: 1, majority: 0, split: 0 },
+    synthesis: 'Paris.',
+    responses: [sampleResponse],
+  };
+
+  const councilResult: EnsembleResult = {
+    ...baseMetadata,
+    schemaVersion: '1.0.0',
+    type: 'council',
+    deliberationRounds: [
+      { round: 1, statements: [{ modelId: 'model-a', statement: 'Paris.', position: 'agree' }] },
+    ],
+    finalVotes: [{ modelId: 'model-a', vote: 'Paris', reasoning: 'Fact.' }],
+    consensusMetrics: { agreementScore: 1, convergenceRate: 1, rounds: 1 },
+    synthesis: 'Paris.',
+    responses: [sampleResponse],
+  };
+
+  it('isStandardResult returns true only for standard', () => {
+    expect(isStandardResult(standardResult)).toBe(true);
+    expect(isStandardResult(eloResult)).toBe(false);
+    expect(isStandardResult(majorityResult)).toBe(false);
+    expect(isStandardResult(councilResult)).toBe(false);
+  });
+
+  it('isEloResult returns true only for elo', () => {
+    expect(isEloResult(eloResult)).toBe(true);
+    expect(isEloResult(standardResult)).toBe(false);
+    expect(isEloResult(majorityResult)).toBe(false);
+    expect(isEloResult(councilResult)).toBe(false);
+  });
+
+  it('isMajorityResult returns true only for majority', () => {
+    expect(isMajorityResult(majorityResult)).toBe(true);
+    expect(isMajorityResult(standardResult)).toBe(false);
+    expect(isMajorityResult(eloResult)).toBe(false);
+    expect(isMajorityResult(councilResult)).toBe(false);
+  });
+
+  it('isCouncilResult returns true only for council', () => {
+    expect(isCouncilResult(councilResult)).toBe(true);
+    expect(isCouncilResult(standardResult)).toBe(false);
+    expect(isCouncilResult(eloResult)).toBe(false);
+    expect(isCouncilResult(majorityResult)).toBe(false);
+  });
+
+  it('narrows type correctly for standard (compile-time check)', () => {
+    if (isStandardResult(standardResult)) {
+      // This should compile without error - synthesis is accessible
+      expect(standardResult.synthesis).toBe('Paris.');
+    }
+  });
+
+  it('narrows type correctly for elo (compile-time check)', () => {
+    if (isEloResult(eloResult)) {
+      expect(eloResult.topN).toBe(1);
+      expect(eloResult.rankings.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('narrows type correctly for majority (compile-time check)', () => {
+    if (isMajorityResult(majorityResult)) {
+      expect(majorityResult.majorityModelId).toBe('model-a');
+      expect(majorityResult.agreementBreakdown.unanimous).toBe(1);
+    }
+  });
+
+  it('narrows type correctly for council (compile-time check)', () => {
+    if (isCouncilResult(councilResult)) {
+      expect(councilResult.deliberationRounds.length).toBe(1);
+      expect(councilResult.consensusMetrics.agreementScore).toBe(1);
+    }
+  });
+});

--- a/packages/shared-utils/src/consensus/index.ts
+++ b/packages/shared-utils/src/consensus/index.ts
@@ -1,3 +1,4 @@
+export * from './schemas';
 export * from './types';
 export * from './StandardConsensus';
 export * from './EloRankingConsensus';

--- a/packages/shared-utils/src/consensus/schemas.ts
+++ b/packages/shared-utils/src/consensus/schemas.ts
@@ -1,0 +1,250 @@
+/**
+ * @module consensus/schemas
+ *
+ * Zod schemas for strategy-specific ensemble result JSON contracts.
+ * These schemas are the **single source of truth** for result shapes.
+ * TypeScript types are inferred via `z.infer<>` in `types.ts`.
+ *
+ * Every schema uses `.passthrough()` so that unknown fields survive
+ * round-tripping through storage, enabling forward compatibility when
+ * new optional fields are added in later schema versions.
+ */
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Shared / reusable schemas
+// ---------------------------------------------------------------------------
+
+/**
+ * Common metadata present on every ensemble result, regardless of
+ * which consensus strategy produced it.
+ */
+export const EnsembleMetadataSchema = z
+  .object({
+    /** ISO 8601 timestamp of when the result was created */
+    timestamp: z.string().datetime(),
+    /** The original user prompt submitted to the ensemble */
+    prompt: z.string(),
+    /** Ordered list of model identifiers that participated */
+    modelIds: z.array(z.string()),
+    /** Model identifier used to produce the final synthesis */
+    summarizerModel: z.string(),
+    /** Semantic version of the schema that produced this result */
+    schemaVersion: z.string().default('1.0.0'),
+  })
+  .passthrough();
+
+/**
+ * A single model's response within an ensemble result.
+ * Captures both the content and performance metrics.
+ */
+export const ModelResponseReferenceSchema = z
+  .object({
+    /** Unique identifier for the model instance */
+    modelId: z.string(),
+    /** Provider name (e.g. 'openai', 'anthropic', 'google', 'xai') */
+    provider: z.string(),
+    /** Provider-specific model identifier (e.g. 'gpt-4o') */
+    model: z.string(),
+    /** Human-readable display name */
+    modelName: z.string(),
+    /** Full text content of the model's response */
+    content: z.string(),
+    /** Wall-clock response time in milliseconds */
+    responseTime: z.number(),
+    /** Number of tokens in the response (if available) */
+    tokenCount: z.number().optional(),
+  })
+  .passthrough();
+
+// ---------------------------------------------------------------------------
+// Strategy-specific result schemas
+// ---------------------------------------------------------------------------
+
+/**
+ * Result produced by the **Standard** consensus strategy.
+ * The summarizer synthesises all model responses into a single answer
+ * without ranking or voting.
+ */
+export const StandardConsensusResultSchema = EnsembleMetadataSchema.extend({
+  type: z.literal('standard'),
+  /** Synthesised answer combining insights from all models */
+  synthesis: z.string(),
+  /** Individual model responses included in this result */
+  responses: z.array(ModelResponseReferenceSchema),
+  /** Optional highlighted excerpts from source responses */
+  sourceHighlights: z
+    .array(
+      z
+        .object({
+          modelId: z.string(),
+          highlight: z.string(),
+        })
+        .passthrough(),
+    )
+    .optional(),
+}).passthrough();
+
+/**
+ * Result produced by the **ELO Ranking** consensus strategy.
+ * Models are ranked via pairwise comparisons judged by an LLM,
+ * then the top-N responses are synthesised.
+ */
+export const EloRankingResultSchema = EnsembleMetadataSchema.extend({
+  type: z.literal('elo'),
+  /** Pairwise comparison outcomes used to compute ELO scores */
+  pairwiseComparisons: z.array(
+    z
+      .object({
+        modelA: z.string(),
+        modelB: z.string(),
+        winner: z.string(),
+        reasoning: z.string(),
+      })
+      .passthrough(),
+  ),
+  /** Final ranked list of models with ELO scores */
+  rankings: z.array(
+    z
+      .object({
+        modelId: z.string(),
+        score: z.number(),
+        rank: z.number(),
+      })
+      .passthrough(),
+  ),
+  /** Number of top-ranked models used for synthesis */
+  topN: z.number(),
+  /** Synthesised answer from top-N models */
+  synthesis: z.string(),
+  /** Individual model responses included in this result */
+  responses: z.array(ModelResponseReferenceSchema),
+  /** Optional bracket visualisation data */
+  tournamentBracket: z.unknown().optional(),
+}).passthrough();
+
+/**
+ * Result produced by the **Majority Voting** consensus strategy.
+ * Responses are scored for alignment with the majority position,
+ * and the majority-aligned model anchors the synthesis.
+ */
+export const MajorityVotingResultSchema = EnsembleMetadataSchema.extend({
+  type: z.literal('majority'),
+  /** Per-model alignment scores (0-100) with the majority position */
+  alignmentScores: z.array(
+    z
+      .object({
+        modelId: z.string(),
+        score: z.number(),
+      })
+      .passthrough(),
+  ),
+  /** Model that best represents the majority position */
+  majorityModelId: z.string(),
+  /** Breakdown of how models agreed or disagreed */
+  agreementBreakdown: z
+    .object({
+      /** Fraction of topics where all models agreed */
+      unanimous: z.number(),
+      /** Fraction of topics where a majority agreed */
+      majority: z.number(),
+      /** Fraction of topics where models were evenly split */
+      split: z.number(),
+    })
+    .passthrough(),
+  /** Synthesised answer anchored on the majority position */
+  synthesis: z.string(),
+  /** Individual model responses included in this result */
+  responses: z.array(ModelResponseReferenceSchema),
+}).passthrough();
+
+/**
+ * Result produced by the **LLM Council** consensus strategy.
+ * Models engage in structured deliberation rounds before casting
+ * final votes to reach consensus.
+ */
+export const LLMCouncilResultSchema = EnsembleMetadataSchema.extend({
+  type: z.literal('council'),
+  /** Rounds of structured deliberation between models */
+  deliberationRounds: z.array(
+    z
+      .object({
+        round: z.number(),
+        statements: z.array(
+          z
+            .object({
+              modelId: z.string(),
+              statement: z.string(),
+              position: z.string(),
+            })
+            .passthrough(),
+        ),
+      })
+      .passthrough(),
+  ),
+  /** Final votes cast by each model after deliberation */
+  finalVotes: z.array(
+    z
+      .object({
+        modelId: z.string(),
+        vote: z.string(),
+        reasoning: z.string(),
+      })
+      .passthrough(),
+  ),
+  /** Aggregate metrics describing how well the council converged */
+  consensusMetrics: z
+    .object({
+      agreementScore: z.number(),
+      convergenceRate: z.number(),
+      rounds: z.number(),
+    })
+    .passthrough(),
+  /** Synthesised answer reflecting the council's consensus */
+  synthesis: z.string(),
+  /** Individual model responses included in this result */
+  responses: z.array(ModelResponseReferenceSchema),
+}).passthrough();
+
+// ---------------------------------------------------------------------------
+// Discriminated union
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated union of all ensemble result types.
+ * The `type` field is the discriminator.
+ *
+ * Use {@link parseEnsembleResult} to safely parse unknown JSON
+ * into this union.
+ */
+export const EnsembleResultSchema = z.discriminatedUnion('type', [
+  StandardConsensusResultSchema,
+  EloRankingResultSchema,
+  MajorityVotingResultSchema,
+  LLMCouncilResultSchema,
+]);
+
+// ---------------------------------------------------------------------------
+// Validation helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Safely parse unknown JSON into a typed {@link EnsembleResult}.
+ *
+ * Returns the standard Zod `SafeParseReturnType` so callers can
+ * inspect `.success`, `.data`, or `.error` as needed.
+ *
+ * @example
+ * ```ts
+ * const result = parseEnsembleResult(jsonFromStorage);
+ * if (result.success) {
+ *   console.log(result.data.type); // 'standard' | 'elo' | 'majority' | 'council'
+ * } else {
+ *   console.error(result.error.issues);
+ * }
+ * ```
+ */
+export function parseEnsembleResult(json: unknown) {
+  return EnsembleResultSchema.safeParse(json);
+}

--- a/packages/shared-utils/src/consensus/types.ts
+++ b/packages/shared-utils/src/consensus/types.ts
@@ -1,3 +1,28 @@
+/**
+ * @module consensus/types
+ *
+ * Core consensus types and Zod-inferred result types.
+ *
+ * Strategy-specific result types (`EnsembleResult`, `StandardConsensusResult`,
+ * etc.) are **inferred from Zod schemas** in `schemas.ts`.  Do not duplicate
+ * them as hand-written interfaces.
+ */
+
+import type { z } from 'zod';
+
+import type {
+    EnsembleMetadataSchema,
+    EnsembleResultSchema,
+    EloRankingResultSchema,
+    LLMCouncilResultSchema,
+    MajorityVotingResultSchema,
+    ModelResponseReferenceSchema,
+    StandardConsensusResultSchema,
+} from './schemas';
+
+// ---------------------------------------------------------------------------
+// Hand-written types (pre-existing, used by strategy classes)
+// ---------------------------------------------------------------------------
 
 export interface ConsensusModelResponse {
     modelId: string;
@@ -5,7 +30,7 @@ export interface ConsensusModelResponse {
     content: string;   // "response" in ModelResponse
 }
 
-export type ConsensusMethod = 'standard' | 'elo' | 'majority';
+export type ConsensusMethod = 'standard' | 'elo' | 'majority' | 'council';
 
 export interface Pairing {
     modelA: ConsensusModelResponse;
@@ -21,4 +46,61 @@ export interface RankingResult {
 export interface ConsensusStrategy {
     rankResponses(responses: ConsensusModelResponse[], prompt: string): Promise<RankingResult[]>;
     generateConsensus(responses: ConsensusModelResponse[], topN: number, prompt: string): Promise<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Zod-inferred result types
+// ---------------------------------------------------------------------------
+
+/** Common metadata present on every ensemble result. */
+export type EnsembleMetadata = z.infer<typeof EnsembleMetadataSchema>;
+
+/** A single model's response within an ensemble result. */
+export type ModelResponseReference = z.infer<typeof ModelResponseReferenceSchema>;
+
+/** Result from the Standard consensus strategy. */
+export type StandardConsensusResult = z.infer<typeof StandardConsensusResultSchema>;
+
+/** Result from the ELO Ranking consensus strategy. */
+export type EloRankingResult = z.infer<typeof EloRankingResultSchema>;
+
+/** Result from the Majority Voting consensus strategy. */
+export type MajorityVotingResult = z.infer<typeof MajorityVotingResultSchema>;
+
+/** Result from the LLM Council consensus strategy. */
+export type LLMCouncilResult = z.infer<typeof LLMCouncilResultSchema>;
+
+/** Discriminated union of all ensemble result types. */
+export type EnsembleResult = z.infer<typeof EnsembleResultSchema>;
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+/**
+ * Narrows an {@link EnsembleResult} to a {@link StandardConsensusResult}.
+ */
+export function isStandardResult(result: EnsembleResult): result is StandardConsensusResult {
+    return result.type === 'standard';
+}
+
+/**
+ * Narrows an {@link EnsembleResult} to an {@link EloRankingResult}.
+ */
+export function isEloResult(result: EnsembleResult): result is EloRankingResult {
+    return result.type === 'elo';
+}
+
+/**
+ * Narrows an {@link EnsembleResult} to a {@link MajorityVotingResult}.
+ */
+export function isMajorityResult(result: EnsembleResult): result is MajorityVotingResult {
+    return result.type === 'majority';
+}
+
+/**
+ * Narrows an {@link EnsembleResult} to an {@link LLMCouncilResult}.
+ */
+export function isCouncilResult(result: EnsembleResult): result is LLMCouncilResult {
+    return result.type === 'council';
 }


### PR DESCRIPTION
## Summary
- Add `zod` dependency to `packages/shared-utils`
- Define Zod schemas for all four strategy result types: Standard, ELO, Majority Voting, LLM Council
- Create `EnsembleResultSchema` as a `z.discriminatedUnion` on the `type` field
- Add `parseEnsembleResult()` validation helper using `safeParse`
- Infer TypeScript types from schemas via `z.infer<>` (single source of truth)
- Add type guard functions: `isStandardResult()`, `isEloResult()`, `isMajorityResult()`, `isCouncilResult()`
- Extend `ConsensusMethod` type to include `'council'`
- All schemas use `.passthrough()` for forward compatibility
- Export everything from `consensus/index.ts` barrel

Closes #187

## Test plan
- [x] All four strategy schemas validate correct JSON
- [x] Invalid JSON rejected with descriptive errors (missing fields, wrong types, wrong discriminator)
- [x] Type guards correctly narrow the discriminated union
- [x] Schema version defaults to "1.0.0" when omitted
- [x] Forward compatibility via `.passthrough()` preserves unknown fields
- [x] `parseEnsembleResult` validates valid input and rejects invalid input
- [x] TypeScript compiles cleanly (shared-utils and app)
- [x] All existing consensus tests continue to pass
- [x] 45 new unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)