### PR TITLE
feat(eval): create GitHub Actions eval workflows (#226)

### DIFF
--- a/.github/workflows/eval-ci.yml
+++ b/.github/workflows/eval-ci.yml
@@ -1,0 +1,106 @@
+name: Eval CI Gate
+
+on:
+  pull_request:
+    paths:
+      - 'packages/shared-utils/**'
+
+concurrency:
+  group: eval-ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  eval-ci:
+    name: Eval CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      TEST_OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
+      TEST_ANTHROPIC_API_KEY: ${{ secrets.TEST_ANTHROPIC_API_KEY }}
+      TEST_GOOGLE_API_KEY: ${{ secrets.TEST_GOOGLE_API_KEY }}
+      TEST_XAI_API_KEY: ${{ secrets.TEST_XAI_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Check API keys are configured
+        id: check-keys
+        run: |
+          if [ -z "$TEST_OPENAI_API_KEY" ]; then
+            echo "::warning::TEST_OPENAI_API_KEY is not set. Skipping eval."
+            echo "keys_available=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "keys_available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build shared-utils
+        if: steps.check-keys.outputs.keys_available == 'true'
+        run: npm run build --workspace=packages/shared-utils
+
+      - name: Build eval
+        if: steps.check-keys.outputs.keys_available == 'true'
+        run: npm run build --workspace=packages/eval
+
+      - name: Run CI evaluation
+        if: steps.check-keys.outputs.keys_available == 'true'
+        id: eval
+        continue-on-error: true
+        run: npx ensemble-eval ci-eval --tier ci
+
+      - name: Upload report artifact
+        if: always() && steps.check-keys.outputs.keys_available == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-ci-report
+          path: eval-report.md
+          if-no-files-found: ignore
+
+      - name: Post PR comment
+        if: always() && steps.check-keys.outputs.keys_available == 'true' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- eval-ci-report -->';
+            let body = marker + '\n';
+            try {
+              body += fs.readFileSync('eval-report.md', 'utf8');
+            } catch {
+              body += '> **Warning**: Eval report was not generated. Check the [workflow logs](' +
+                `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}` +
+                ') for details.';
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body?.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail if evaluation detected regressions
+        if: steps.eval.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/eval-post-merge.yml
+++ b/.github/workflows/eval-post-merge.yml
@@ -1,0 +1,68 @@
+name: Eval Post-Merge
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/shared-utils/**'
+
+concurrency:
+  group: eval-post-merge
+  cancel-in-progress: false
+
+jobs:
+  eval-post-merge:
+    name: Eval Post-Merge
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      TEST_OPENAI_API_KEY: ${{ secrets.TEST_OPENAI_API_KEY }}
+      TEST_ANTHROPIC_API_KEY: ${{ secrets.TEST_ANTHROPIC_API_KEY }}
+      TEST_GOOGLE_API_KEY: ${{ secrets.TEST_GOOGLE_API_KEY }}
+      TEST_XAI_API_KEY: ${{ secrets.TEST_XAI_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Check API keys are configured
+        id: check-keys
+        run: |
+          if [ -z "$TEST_OPENAI_API_KEY" ]; then
+            echo "::warning::TEST_OPENAI_API_KEY is not set. Skipping eval."
+            echo "keys_available=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "keys_available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build shared-utils
+        if: steps.check-keys.outputs.keys_available == 'true'
+        run: npm run build --workspace=packages/shared-utils
+
+      - name: Build eval
+        if: steps.check-keys.outputs.keys_available == 'true'
+        run: npm run build --workspace=packages/eval
+
+      - name: Run post-merge evaluation
+        if: steps.check-keys.outputs.keys_available == 'true'
+        id: eval
+        continue-on-error: true
+        run: npx ensemble-eval ci-eval --tier post-merge
+
+      - name: Upload report artifact
+        if: always() && steps.check-keys.outputs.keys_available == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-post-merge-report
+          path: eval-report.md
+          if-no-files-found: ignore
+
+      - name: Fail if evaluation detected regressions
+        if: steps.eval.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
## Summary
- Add `eval-ci.yml` workflow triggered on PRs modifying `packages/shared-utils/**`
  - Runs `ci-eval --tier ci` regression check (10-minute timeout)
  - Posts Markdown report as PR comment (updates existing comment on re-runs using HTML marker)
  - Uploads report as artifact
  - Concurrency group per PR number prevents parallel runs competing for API rate limits
- Add `eval-post-merge.yml` workflow triggered on pushes to main modifying `packages/shared-utils/**`
  - Runs `ci-eval --tier post-merge` thorough evaluation (30-minute timeout)
  - Uploads report as artifact
  - Concurrency group prevents parallel runs
- Both workflows gracefully skip with a warning when API keys are not configured

Closes #226

## Test plan
- [x] YAML syntax validated
- [x] CI workflow triggers on `packages/shared-utils/**` changes in PRs
- [x] Post-merge workflow triggers on `packages/shared-utils/**` changes pushed to main
- [x] PR comment uses `<!-- eval-ci-report -->` HTML marker for update-in-place
- [x] Reports uploaded as artifacts with `if-no-files-found: ignore`
- [x] Concurrency groups configured to prevent parallel API-competing runs
- [x] Graceful skip when `TEST_OPENAI_API_KEY` is not set
- [ ] End-to-end validation with real API keys (requires secrets to be configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)