### PR TITLE
fix(eval): fix 6 critical evaluation pipeline bugs

### DIFF
--- a/packages/eval/src/lib/consensus.test.ts
+++ b/packages/eval/src/lib/consensus.test.ts
@@ -25,6 +25,20 @@ describe('consensus', () => {
     );
   });
 
+  it('omits ELO key when fewer than 3 responses are available', async () => {
+    const result = await generateConsensus(
+      ['elo'],
+      'Q',
+      [
+        { provider: 'openai', model: 'a', content: 'A', responseTimeMs: 5 },
+        { provider: 'anthropic', model: 'b', content: 'B', responseTimeMs: 6 },
+      ],
+      buildProvider(async () => undefined),
+      'judge-model',
+    );
+    expect(result.elo).toBeUndefined();
+  });
+
   it('handles majority strategy for insufficient and sufficient response counts', async () => {
     const insufficient = await generateConsensus(
       ['majority'],
@@ -40,7 +54,7 @@ describe('consensus', () => {
       buildProvider(async () => undefined),
       'judge-model',
     );
-    expect(insufficient.majority).toContain('requires at least 2');
+    expect(insufficient.majority).toBeUndefined();
 
     let callCount = 0;
     const provider = buildProvider(async (_prompt, _model, _onChunk, onComplete) => {

--- a/packages/eval/src/lib/consensus.ts
+++ b/packages/eval/src/lib/consensus.ts
@@ -65,8 +65,8 @@ export async function generateConsensus(
 
     if (strategy === 'elo') {
       if (consensusResponses.length < MIN_RESPONSES_FOR_ELO) {
-        outputs.elo =
-          `ELO strategy requires at least ${MIN_RESPONSES_FOR_ELO} successful model responses.`;
+        // Omit key entirely — downstream evaluators would otherwise parse the
+        // error string as if it were a model answer.
         continue;
       }
 
@@ -86,8 +86,8 @@ export async function generateConsensus(
 
     if (strategy === 'majority') {
       if (consensusResponses.length < MIN_RESPONSES_FOR_MAJORITY) {
-        outputs.majority =
-          `Majority strategy requires at least ${MIN_RESPONSES_FOR_MAJORITY} successful model responses.`;
+        // Omit key entirely — downstream evaluators would otherwise parse the
+        // error string as if it were a model answer.
         continue;
       }
 

--- a/packages/eval/src/lib/evaluation.test.ts
+++ b/packages/eval/src/lib/evaluation.test.ts
@@ -123,6 +123,29 @@ describe('evaluateConsensusStrategies', () => {
     expect(evaluator.evaluate).toHaveBeenCalledWith('99', '42', 'prompt text');
   });
 
+  it('skips consensus entries that are error strings', async () => {
+    const evaluator = {
+      name: 'numeric' as const,
+      evaluate: vi.fn(() => ({ correct: false, expected: '42', predicted: '3' })),
+    };
+
+    const result = await evaluateConsensusStrategies(
+      evaluator,
+      {
+        standard: '42',
+        elo: 'ELO strategy requires at least 3 successful model responses.',
+        majority: 'Majority strategy requires at least 2 successful model responses.',
+      },
+      '42',
+    );
+
+    // Only standard should be evaluated; error strings should be skipped
+    expect(evaluator.evaluate).toHaveBeenCalledTimes(1);
+    expect(result?.results.standard).toBeDefined();
+    expect(result?.results.elo).toBeUndefined();
+    expect(result?.results.majority).toBeUndefined();
+  });
+
   it('skips empty consensus entries', async () => {
     const evaluator = {
       name: 'mcq' as const,

--- a/packages/eval/src/lib/evaluators.test.ts
+++ b/packages/eval/src/lib/evaluators.test.ts
@@ -39,6 +39,26 @@ describe('extractChoiceLetter', () => {
   it('extracts selected choices from natural phrasing', () => {
     expect(extractChoiceLetter('I choose option d.')).toBe('D');
   });
+
+  it('extracts "The correct answer is A"', () => {
+    expect(extractChoiceLetter('The correct answer is A')).toBe('A');
+  });
+
+  it('extracts "The answer is (B)"', () => {
+    expect(extractChoiceLetter('The answer is (B)')).toBe('B');
+  });
+
+  it('extracts "(A) is correct"', () => {
+    expect(extractChoiceLetter('(A) is correct')).toBe('A');
+  });
+
+  it('extracts "Option C is correct"', () => {
+    expect(extractChoiceLetter('Option C is correct')).toBe('C');
+  });
+
+  it('extracts "The correct answer is (D)"', () => {
+    expect(extractChoiceLetter('The correct answer is (D)')).toBe('D');
+  });
 });
 
 describe('NumericEvaluator', () => {

--- a/packages/eval/src/lib/parsers.ts
+++ b/packages/eval/src/lib/parsers.ts
@@ -32,16 +32,36 @@ export function extractNumericAnswer(value: string): string | null {
 }
 
 export function extractChoiceLetter(value: string): string | null {
+  // \boxed{A}
   const boxedMatch = value.match(/\\boxed\{\s*([A-Z])\s*\}/i);
   if (boxedMatch) {
     return boxedMatch[1].toUpperCase();
   }
 
+  // "answer: A", "option A", "choice A"
   const answerMatch = value.match(/\b(?:answer|option|choice)\s*[:\-]?\s*([A-Z])\b/i);
   if (answerMatch) {
     return answerMatch[1].toUpperCase();
   }
 
+  // "The correct answer is A", "The answer is (A)", "The correct answer is (B)"
+  const correctAnswerMatch = value.match(
+    /\bthe\s+(?:correct\s+)?answer\s+is\s+\(?([A-Z])\)?(?!\w)/i,
+  );
+  if (correctAnswerMatch) {
+    return correctAnswerMatch[1].toUpperCase();
+  }
+
+  // "(A) is correct", "Option A is correct"
+  const isCorrectMatch = value.match(
+    /\b(?:option\s+)?(\(?[A-Z]\)?)\s+is\s+correct\b/i,
+  );
+  if (isCorrectMatch) {
+    const letter = isCorrectMatch[1].replace(/[()]/g, '');
+    return letter.toUpperCase();
+  }
+
+  // "choose A", "chose B", "pick C", "selected D"
   const selectedChoice = findLastCapturedGroup(
     value,
     /\b(?:choose|chose|pick|picked|select|selected)\b(?:\s+option)?\s*\(?([A-Z])\)?\b/gi,
@@ -50,6 +70,7 @@ export function extractChoiceLetter(value: string): string | null {
     return selectedChoice.toUpperCase();
   }
 
+  // Bare "A." or "(A)" at start of response
   const directChoiceMatch = value.trim().match(/^\(?\s*([A-Z])\s*\)?[.)]?\s*$/i);
   if (directChoiceMatch) {
     return directChoiceMatch[1].toUpperCase();


### PR DESCRIPTION
## Summary

Fixes 6 critical bugs in the eval pipeline that made every consensus strategy perform worse than the best individual model in golden baselines:

1. **ciEval uses wrong evaluator for all datasets** — `ciEval.ts:87` created evaluator from `tierConfig.datasets[0].name` (always gsm8k → NumericEvaluator), so TruthfulQA and GPQA could never be correctly evaluated. Fixed with per-dataset `RunnerFactory`.

2. **Error strings evaluated as answers** — `evaluation.ts` now detects consensus error strings (e.g. "ELO strategy requires at least 3...") and skips them instead of passing them to evaluators, where `NumericEvaluator` would extract "3" and mark it correct only when ground truth happened to be "3".

3. **Consensus stores error strings as output** — ELO and majority guards in `consensus.ts` now omit the key entirely instead of storing error message strings.

4. **MCQ parser too restrictive** — `parsers.ts:extractChoiceLetter` now handles common phrasings: "The correct answer is A", "The answer is (B)", "(A) is correct", "Option C is correct".

5. **Significant improvements fail CI** — `regression.ts:327` now checks `!result.significant || result.delta >= 0` so improvements don't fail the gate.

6. **`RegressionDetector` backward compatibility** — Constructor accepts either a `BenchmarkRunner` (legacy) or a `RunnerFactory` function.

## Test plan

- [x] All 359 eval tests pass
- [x] TypeScript type checking passes
- [x] New tests for error string handling in `evaluation.test.ts`
- [x] New tests for ELO key omission in `consensus.test.ts`
- [x] New MCQ parser pattern tests in `evaluators.test.ts`
- [x] New test for significant improvement passing in `regression.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)