### PR TITLE
feat(eval): add ensemble vs individual delta metric

### DIFF
--- a/packages/eval/src/lib/regression.test.ts
+++ b/packages/eval/src/lib/regression.test.ts
@@ -96,6 +96,14 @@ function makeRunResult(
       },
     ],
     consensus,
+    evaluation: {
+      evaluator: 'numeric' as const,
+      groundTruth,
+      accuracy: 1,
+      results: {
+        'openai:gpt-4o-mini': makeEvalResult(true, groundTruth, groundTruth),
+      },
+    },
     consensusEvaluation: {
       evaluator: 'numeric',
       groundTruth,
@@ -570,6 +578,45 @@ describe('RegressionDetector', () => {
     });
   });
 
+  describe('ensemble delta', () => {
+    it('computes ensemble delta comparing best strategy vs best model', async () => {
+      const baselineQuestions = [
+        makeBaselineQuestion('q1', 'gsm8k', '42', {
+          standard: makeEvalResult(true, '42', '42'),
+        }),
+        makeBaselineQuestion('q2', 'gsm8k', '7', {
+          standard: makeEvalResult(true, '7', '7'),
+        }),
+        makeBaselineQuestion('q3', 'gsm8k', '100', {
+          standard: makeEvalResult(false, '99', '100'),
+        }),
+      ];
+
+      const tier = makeTierConfig({
+        strategies: ['standard'],
+        datasets: [{ name: 'gsm8k', sampleSize: 3 }],
+      });
+      const baseline = makeBaseline(baselineQuestions);
+
+      // Individual model: 2/3 correct. Consensus (standard): 3/3 correct.
+      const runner = mockRunner(() => [
+        makeRunResult('q1', '42', { standard: true }),
+        makeRunResult('q2', '7', { standard: true }),
+        makeRunResult('q3', '100', { standard: true }),
+      ]);
+
+      const detector = new RegressionDetector(tier, baseline, runner);
+      const result = await detector.evaluate();
+
+      expect(result.ensembleDelta).toBeDefined();
+      expect(result.ensembleDelta!.bestModelName).toBe('openai:gpt-4o-mini');
+      expect(result.ensembleDelta!.bestStrategyName).toBe('standard');
+      // Model gets 3/3 correct (mock responses contain groundTruth),
+      // strategy also 3/3 => delta = 0
+      expect(result.ensembleDelta!.delta).toBeCloseTo(0);
+    });
+  });
+
   describe('progress callback', () => {
     it('invokes onProgress during evaluation', async () => {
       const baselineQuestions = [
@@ -697,6 +744,7 @@ describe('RegressionDetector', () => {
       expect(result).toHaveProperty('brokenQuestions');
       expect(result).toHaveProperty('stability');
       expect(result).toHaveProperty('cost');
+      expect(result).toHaveProperty('ensembleDelta');
 
       // Verify types
       expect(typeof result.tier).toBe('string');

--- a/packages/eval/src/lib/regressionReport.ts
+++ b/packages/eval/src/lib/regressionReport.ts
@@ -1,4 +1,4 @@
-import type { RegressionResult, StrategyRegressionResult, BrokenQuestion } from './regressionTypes.js';
+import type { EnsembleDelta, RegressionResult, StrategyRegressionResult, BrokenQuestion } from './regressionTypes.js';
 
 /** Options for controlling the regression report output. */
 export interface RegressionReportOptions {
@@ -146,6 +146,24 @@ function renderStability(result: RegressionResult): string[] {
   return lines;
 }
 
+function renderEnsembleValue(delta: EnsembleDelta | undefined): string[] {
+  if (!delta) return [];
+
+  const lines: string[] = [];
+  const icon = delta.delta >= 0 ? ':white_check_mark:' : ':warning:';
+
+  lines.push('## Ensemble Value');
+  lines.push('');
+  lines.push(`| | |`);
+  lines.push(`| --- | ---: |`);
+  lines.push(`| **Best Model** | ${delta.bestModelName} (${toPercent(delta.bestModelAccuracy)}) |`);
+  lines.push(`| **Best Strategy** | ${delta.bestStrategyName} (${toPercent(delta.bestStrategyAccuracy)}) |`);
+  lines.push(`| **Delta** | ${toDelta(delta.delta)} ${icon} |`);
+  lines.push('');
+
+  return lines;
+}
+
 function renderCost(result: RegressionResult): string[] {
   const lines: string[] = [];
   const { cost } = result;
@@ -189,6 +207,7 @@ export function createRegressionReport(
     lines.push(...renderChangedFiles(changedFiles));
   }
 
+  lines.push(...renderEnsembleValue(result.ensembleDelta));
   lines.push(...renderStability(result));
   lines.push(...renderCost(result));
 

--- a/packages/eval/src/lib/regressionTypes.ts
+++ b/packages/eval/src/lib/regressionTypes.ts
@@ -109,6 +109,20 @@ export interface CostMetrics {
   durationMs: number;
 }
 
+/** Measures whether ensemble consensus adds value over individual models. */
+export interface EnsembleDelta {
+  /** Accuracy of the best individual model across all datasets. */
+  bestModelAccuracy: number;
+  /** Name of the best individual model (e.g. "openai:gpt-4o-mini"). */
+  bestModelName: string;
+  /** Accuracy of the best consensus strategy across all datasets. */
+  bestStrategyAccuracy: number;
+  /** Name of the best consensus strategy (e.g. "standard"). */
+  bestStrategyName: StrategyName;
+  /** Difference: bestStrategyAccuracy - bestModelAccuracy. Positive = ensemble adds value. */
+  delta: number;
+}
+
 /** Complete output of a regression evaluation comparing current code against a baseline. */
 export interface RegressionResult {
   /** The evaluation tier that produced this result. */
@@ -129,4 +143,6 @@ export interface RegressionResult {
   stability: StabilityMetrics | undefined;
   /** Cost and resource usage for this evaluation. */
   cost: CostMetrics;
+  /** Ensemble value: does consensus beat the best individual model? */
+  ensembleDelta?: EnsembleDelta;
 }


### PR DESCRIPTION
## Summary

Adds the most important eval metric: **does consensus beat the best individual model?**

- **`EnsembleDelta` type** in `regressionTypes.ts` — captures best model accuracy, best strategy accuracy, and the delta between them
- **`computeEnsembleDelta()`** in `regression.ts` — calculates per-model accuracy from evaluation results and compares against per-strategy accuracy
- **"Ensemble Value" section** in regression report — shows best individual model vs best consensus strategy with positive/negative delta indicator
- **Positive delta** = ensemble adds value; negative = individual model is better

**Depends on**: #255

## Test plan

- [x] All 378 eval tests pass (4 new)
- [x] TypeScript type checking passes
- [x] New regression test for ensemble delta computation
- [x] New report tests for ensemble value section (positive, negative, undefined)
- [x] Result shape test updated to verify ensembleDelta field

🤖 Generated with [Claude Code](https://claude.com/claude-code)