### PR TITLE
feat(consensus): implement 17 strategy improvements across all consensus methods

### DIFF
--- a/packages/eval/src/lib/evaluators.test.ts
+++ b/packages/eval/src/lib/evaluators.test.ts
@@ -59,6 +59,38 @@ describe('extractChoiceLetter', () => {
   it('extracts "The correct answer is (D)"', () => {
     expect(extractChoiceLetter('The correct answer is (D)')).toBe('D');
   });
+
+  it('handles markdown bold **A**', () => {
+    expect(extractChoiceLetter('**A**')).toBe('A');
+  });
+
+  it('handles "The correct answer is **A**"', () => {
+    expect(extractChoiceLetter('The correct answer is **A**')).toBe('A');
+  });
+
+  it('handles "The correct option is A"', () => {
+    expect(extractChoiceLetter('The correct option is A')).toBe('A');
+  });
+
+  it('handles "The best answer is B"', () => {
+    expect(extractChoiceLetter('The best answer is B')).toBe('B');
+  });
+
+  it('handles "The best option is C"', () => {
+    expect(extractChoiceLetter('The best option is C')).toBe('C');
+  });
+
+  it('handles "A. Some option text" at start of line', () => {
+    expect(extractChoiceLetter('A. Bananas are yellow')).toBe('A');
+  });
+
+  it('handles bare letter on last line after reasoning', () => {
+    expect(extractChoiceLetter('Let me think about this...\nB')).toBe('B');
+  });
+
+  it('handles markdown underscore __D__', () => {
+    expect(extractChoiceLetter('__D__')).toBe('D');
+  });
 });
 
 describe('NumericEvaluator', () => {

--- a/packages/eval/src/lib/parsers.ts
+++ b/packages/eval/src/lib/parsers.ts
@@ -32,28 +32,31 @@ export function extractNumericAnswer(value: string): string | null {
 }
 
 export function extractChoiceLetter(value: string): string | null {
+  // Strip markdown bold/italic markers so **A** and __A__ are treated as bare A
+  const cleaned = value.replace(/\*{1,2}([^*]+)\*{1,2}/g, '$1').replace(/_{1,2}([^_]+)_{1,2}/g, '$1');
+
   // \boxed{A}
-  const boxedMatch = value.match(/\\boxed\{\s*([A-Z])\s*\}/i);
+  const boxedMatch = cleaned.match(/\\boxed\{\s*([A-Z])\s*\}/i);
   if (boxedMatch) {
     return boxedMatch[1].toUpperCase();
   }
 
   // "answer: A", "option A", "choice A"
-  const answerMatch = value.match(/\b(?:answer|option|choice)\s*[:\-]?\s*([A-Z])\b/i);
+  const answerMatch = cleaned.match(/\b(?:answer|option|choice)\s*[:\-]?\s*([A-Z])\b/i);
   if (answerMatch) {
     return answerMatch[1].toUpperCase();
   }
 
-  // "The correct answer is A", "The answer is (A)", "The correct answer is (B)"
-  const correctAnswerMatch = value.match(
-    /\bthe\s+(?:correct\s+)?answer\s+is\s+\(?([A-Z])\)?(?!\w)/i,
+  // "The correct/best answer/option is A", "The answer is (A)", "The correct answer is (B)"
+  const correctAnswerMatch = cleaned.match(
+    /\bthe\s+(?:correct\s+|best\s+)?(?:answer|option)\s+is\s+\(?([A-Z])\)?(?!\w)/i,
   );
   if (correctAnswerMatch) {
     return correctAnswerMatch[1].toUpperCase();
   }
 
   // "(A) is correct", "Option A is correct"
-  const isCorrectMatch = value.match(
+  const isCorrectMatch = cleaned.match(
     /\b(?:option\s+)?(\(?[A-Z]\)?)\s+is\s+correct\b/i,
   );
   if (isCorrectMatch) {
@@ -63,17 +66,33 @@ export function extractChoiceLetter(value: string): string | null {
 
   // "choose A", "chose B", "pick C", "selected D"
   const selectedChoice = findLastCapturedGroup(
-    value,
+    cleaned,
     /\b(?:choose|chose|pick|picked|select|selected)\b(?:\s+option)?\s*\(?([A-Z])\)?\b/gi,
   );
   if (selectedChoice) {
     return selectedChoice.toUpperCase();
   }
 
+  // "A. [option text]" at start of line (common MCQ format)
+  const mcqFormatMatch = cleaned.match(/^([A-Z])\.\s+\S/im);
+  if (mcqFormatMatch) {
+    return mcqFormatMatch[1].toUpperCase();
+  }
+
   // Bare "A." or "(A)" at start of response
-  const directChoiceMatch = value.trim().match(/^\(?\s*([A-Z])\s*\)?[.)]?\s*$/i);
+  const directChoiceMatch = cleaned.trim().match(/^\(?\s*([A-Z])\s*\)?[.)]?\s*$/i);
   if (directChoiceMatch) {
     return directChoiceMatch[1].toUpperCase();
+  }
+
+  // Bare letter on the last non-empty line
+  const lines = cleaned.trim().split('\n');
+  const lastLine = lines[lines.length - 1]?.trim();
+  if (lastLine && /^\(?([A-Z])\)?[.)]?$/i.test(lastLine)) {
+    const match = lastLine.match(/([A-Z])/i);
+    if (match) {
+      return match[1].toUpperCase();
+    }
   }
 
   return null;

--- a/packages/shared-utils/src/consensus/CouncilConsensus.ts
+++ b/packages/shared-utils/src/consensus/CouncilConsensus.ts
@@ -1,4 +1,4 @@
-import type { AIProvider } from '../providers/types';
+import type { AIProvider, StreamResponseOptions } from '../providers/types';
 import type { ConsensusModelResponse, ConsensusStrategy, RankingResult } from './types';
 import type {
     CouncilParticipant,
@@ -142,13 +142,14 @@ export class CouncilConsensus implements ConsensusStrategy {
         }
     }
 
-    private completePrompt(provider: AIProvider, modelId: string, prompt: string): Promise<string> {
+    private completePrompt(provider: AIProvider, modelId: string, prompt: string, options?: StreamResponseOptions): Promise<string> {
         return new Promise((resolve, reject) => {
             provider.streamResponse(
                 prompt, modelId,
                 () => { void 0; },
                 (finalText: string) => resolve(finalText),
-                (err: Error) => reject(err)
+                (err: Error) => reject(err),
+                options,
             );
         });
     }

--- a/packages/shared-utils/src/consensus/SelfConsistencyConsensus.ts
+++ b/packages/shared-utils/src/consensus/SelfConsistencyConsensus.ts
@@ -1,0 +1,51 @@
+import type { ConsensusModelResponse, ConsensusStrategy, RankingResult } from './types';
+
+/**
+ * Self-consistency consensus strategy: extracts a short answer from each
+ * ensemble response and picks the plurality winner. Requires zero extra
+ * LLM calls — useful as a cheap baseline to measure whether simple voting
+ * beats LLM-mediated synthesis for constrained-answer questions (MCQ, numeric).
+ */
+export class SelfConsistencyConsensus implements ConsensusStrategy {
+    constructor(
+        private extractAnswer: (content: string) => string | null
+    ) {}
+
+    async rankResponses(responses: ConsensusModelResponse[], _prompt: string): Promise<RankingResult[]> {
+        const answerCounts = this.countAnswers(responses);
+        const sorted = [...answerCounts.entries()].sort((a, b) => b[1] - a[1]);
+
+        return responses.map((r) => {
+            const answer = this.extractAnswer(r.content);
+            const count = answer ? (answerCounts.get(answer) ?? 0) : 0;
+            const rank = answer ? (sorted.findIndex(([a]) => a === answer) + 1) : sorted.length + 1;
+            return { modelId: r.modelId, eloScore: count, rank };
+        });
+    }
+
+    async generateConsensus(responses: ConsensusModelResponse[], _topN: number, _prompt: string): Promise<string> {
+        const answerCounts = this.countAnswers(responses);
+
+        let bestAnswer: string | null = null;
+        let bestCount = 0;
+        for (const [answer, count] of answerCounts.entries()) {
+            if (count > bestCount) {
+                bestAnswer = answer;
+                bestCount = count;
+            }
+        }
+
+        return bestAnswer ?? responses[0]?.content ?? '';
+    }
+
+    private countAnswers(responses: ConsensusModelResponse[]): Map<string, number> {
+        const counts = new Map<string, number>();
+        for (const r of responses) {
+            const answer = this.extractAnswer(r.content);
+            if (answer) {
+                counts.set(answer, (counts.get(answer) ?? 0) + 1);
+            }
+        }
+        return counts;
+    }
+}

--- a/packages/shared-utils/src/consensus/StandardConsensus.ts
+++ b/packages/shared-utils/src/consensus/StandardConsensus.ts
@@ -24,12 +24,10 @@ export class StandardConsensus implements ConsensusStrategy {
     }
 
     async generateConsensus(responses: ConsensusModelResponse[], topN: number, originalPrompt: string): Promise<string> {
-        // Standard consensus uses ALL responses, ignoring topN in principle,
-        // OR we can say "Standard" implies Top N = All?
-        // Usually standard means "Summarize everything".
-        void topN; // Unused
+        // Use topN to slice responses when set; 0 means use all
+        const effectiveResponses = topN > 0 ? responses.slice(0, topN) : responses;
 
-        const responsesText = responses.map(r => `Model: ${r.modelName}\nResponse:\n${r.content}`).join('\n\n---\n\n');
+        const responsesText = effectiveResponses.map((r, i) => `Response ${i + 1}:\n${r.content}`).join('\n\n---\n\n');
 
         const prompt = `
 You are a helpful assistant tasked with synthesizing multiple AI responses into a single, enhanced answer.
@@ -43,6 +41,7 @@ Your task is to produce a SINGLE, UNIFIED response that directly answers the ori
 Do NOT compare or analyze the responses. Do NOT mention "models agree/disagree" or reference the individual responses.
 Instead, synthesize the best elements from all responses into one coherent, comprehensive answer that a user would receive as the final response to their question.
 Write as if you are directly answering the original question yourself, enhanced by the collective intelligence of the ensemble.
+If the question asks for a constrained format (single letter, number, JSON, etc.), output exactly that format and nothing else. No markdown formatting.
         `.trim();
 
         return new Promise((resolve) => {

--- a/packages/shared-utils/src/consensus/__tests__/CouncilConsensus.test.ts
+++ b/packages/shared-utils/src/consensus/__tests__/CouncilConsensus.test.ts
@@ -38,8 +38,8 @@ function setupDeterministicProviders(participants: CouncilParticipant[], summari
             _onChunk: (chunk: string) => void,
             onComplete: (full: string, time: number, tokens?: number) => void
         ) => {
-            if (prompt.includes('critical reviewer')) {
-                onComplete('This response has some strengths but lacks detail on key aspects.', 100, 10);
+            if (prompt.includes('factual accuracy reviewer')) {
+                onComplete('FACTUAL ASSESSMENT: correct\nISSUES: none\nVERDICT: keep', 100, 10);
                 return Promise.resolve();
             }
             if (prompt.includes('defending your original response')) {
@@ -50,12 +50,9 @@ function setupDeterministicProviders(participants: CouncilParticipant[], summari
                 onComplete('{"isValid": true, "reasoning": "Position is sound."}', 100, 10);
                 return Promise.resolve();
             }
-            if (prompt.includes('impartial judge')) {
-                if (prompt.includes('Model A')) {
-                    onComplete('Winner: Model A', 100, 10);
-                } else {
-                    onComplete('Winner: Model B', 100, 10);
-                }
+            if (prompt.includes('impartial evaluator')) {
+                // Council ELO now uses anonymous labels (Response A/B → WINNER: A/B)
+                onComplete('WINNER: A', 100, 10);
                 return Promise.resolve();
             }
             onComplete('Default response', 100, 10);
@@ -209,7 +206,7 @@ describe('CouncilConsensus', () => {
                     _onChunk: (chunk: string) => void,
                     onComplete: (full: string, time: number, tokens?: number) => void
                 ) => {
-                    if (prompt.includes('critical reviewer')) {
+                    if (prompt.includes('factual accuracy reviewer')) {
                         onComplete('Good critique.', 100, 10);
                         return Promise.resolve();
                     }
@@ -221,8 +218,8 @@ describe('CouncilConsensus', () => {
                         onComplete('{"isValid": true, "reasoning": "OK"}', 100, 10);
                         return Promise.resolve();
                     }
-                    if (prompt.includes('impartial judge')) {
-                        onComplete('Winner: Model B', 100, 10);
+                    if (prompt.includes('impartial evaluator')) {
+                        onComplete('WINNER: A', 100, 10);
                         return Promise.resolve();
                     }
                     onComplete('Default', 100, 10);
@@ -254,7 +251,7 @@ describe('CouncilConsensus', () => {
                     _onChunk: (chunk: string) => void,
                     onComplete: (full: string, time: number, tokens?: number) => void
                 ) => {
-                    if (prompt.includes('critical reviewer')) {
+                    if (prompt.includes('factual accuracy reviewer')) {
                         onComplete('Major flaws found.', 100, 10);
                         return Promise.resolve();
                     }
@@ -266,8 +263,8 @@ describe('CouncilConsensus', () => {
                         onComplete('{"isValid": false, "reasoning": "Fundamentally flawed."}', 100, 10);
                         return Promise.resolve();
                     }
-                    if (prompt.includes('impartial judge')) {
-                        onComplete('Winner: Model A', 100, 10);
+                    if (prompt.includes('impartial evaluator')) {
+                        onComplete('WINNER: A', 100, 10);
                         return Promise.resolve();
                     }
                     onComplete('Default', 100, 10);
@@ -348,7 +345,7 @@ describe('CouncilConsensus', () => {
             // Check that more than one participant handled ELO judging calls
             const eloCallCounts = participants.map((p) => {
                 const calls = (p.provider.streamResponse as Mock).mock.calls;
-                return calls.filter((c: string[]) => c[0].includes('impartial judge')).length;
+                return calls.filter((c: string[]) => c[0].includes('impartial evaluator')).length;
             });
             const participantsUsedForElo = eloCallCounts.filter((c) => c > 0).length;
             expect(participantsUsedForElo).toBeGreaterThan(1);

--- a/packages/shared-utils/src/consensus/__tests__/SelfConsistencyConsensus.test.ts
+++ b/packages/shared-utils/src/consensus/__tests__/SelfConsistencyConsensus.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { SelfConsistencyConsensus } from '../SelfConsistencyConsensus';
+import type { ConsensusModelResponse } from '../types';
+
+function simpleExtractor(content: string): string | null {
+    const match = content.match(/^([A-Z])$/);
+    return match ? match[1] : null;
+}
+
+describe('SelfConsistencyConsensus', () => {
+    const responses: ConsensusModelResponse[] = [
+        { modelId: 'model-a', modelName: 'Model A', content: 'B' },
+        { modelId: 'model-b', modelName: 'Model B', content: 'A' },
+        { modelId: 'model-c', modelName: 'Model C', content: 'B' },
+    ];
+
+    it('should return the plurality answer', async () => {
+        const strategy = new SelfConsistencyConsensus(simpleExtractor);
+        const result = await strategy.generateConsensus(responses, 0, 'What is it?');
+        expect(result).toBe('B');
+    });
+
+    it('should rank responses by answer frequency', async () => {
+        const strategy = new SelfConsistencyConsensus(simpleExtractor);
+        const rankings = await strategy.rankResponses(responses, 'What is it?');
+
+        expect(rankings).toHaveLength(3);
+        const bModels = rankings.filter((r) => r.eloScore === 2);
+        expect(bModels).toHaveLength(2);
+    });
+
+    it('should fall back to first response content when no answers are extracted', async () => {
+        const noMatch = new SelfConsistencyConsensus(() => null);
+        const result = await noMatch.generateConsensus(responses, 0, 'Q');
+        expect(result).toBe('B');
+    });
+
+    it('should handle all-unique answers by picking first occurrence', async () => {
+        const unique: ConsensusModelResponse[] = [
+            { modelId: 'm1', modelName: 'M1', content: 'A' },
+            { modelId: 'm2', modelName: 'M2', content: 'B' },
+            { modelId: 'm3', modelName: 'M3', content: 'C' },
+        ];
+        const strategy = new SelfConsistencyConsensus(simpleExtractor);
+        const result = await strategy.generateConsensus(unique, 0, 'Q');
+        // All have count 1, first one encountered wins
+        expect(['A', 'B', 'C']).toContain(result);
+    });
+});

--- a/packages/shared-utils/src/consensus/__tests__/StandardConsensus.test.ts
+++ b/packages/shared-utils/src/consensus/__tests__/StandardConsensus.test.ts
@@ -1,3 +1,4 @@
+
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { StandardConsensus } from '../StandardConsensus';
 import type { ConsensusModelResponse } from '../types';
@@ -10,6 +11,7 @@ describe('StandardConsensus', () => {
     const mockResponses: ConsensusModelResponse[] = [
         { modelId: 'model-a', modelName: 'Model A', content: 'Response A content' },
         { modelId: 'model-b', modelName: 'Model B', content: 'Response B content' },
+        { modelId: 'model-c', modelName: 'Model C', content: 'Response C content' },
     ];
 
     beforeEach(() => {
@@ -24,9 +26,9 @@ describe('StandardConsensus', () => {
         strategy = new StandardConsensus(mockSummarizerProvider, 'summarizer-model-id');
     });
 
-    it('should generate summary using all responses', async () => {
+    it('should generate summary using all responses when topN is 0', async () => {
         (mockSummarizerProvider.streamResponse as Mock).mockImplementation(async (
-            prompt: string,
+            _prompt: string,
             _model: string,
             _onChunk: (chunk: string) => void,
             onComplete: (full: string, time: number, tokens?: number) => void
@@ -35,15 +37,45 @@ describe('StandardConsensus', () => {
             return Promise.resolve();
         });
 
-        const summary = await strategy.generateConsensus(mockResponses, 999, 'Test Prompt');
+        const summary = await strategy.generateConsensus(mockResponses, 0, 'Test Prompt');
 
         expect(summary).toBe('Standard Summary');
 
         const calls = (mockSummarizerProvider.streamResponse as Mock).mock.calls;
         const promptArg = calls[0][0];
 
-        expect(promptArg).toContain('Model A');
-        expect(promptArg).toContain('Model B');
+        // Should use anonymous labels, not model names
+        expect(promptArg).toContain('Response 1:');
+        expect(promptArg).toContain('Response 2:');
+        expect(promptArg).toContain('Response 3:');
+        expect(promptArg).not.toContain('Model: Model A');
+        expect(promptArg).not.toContain('Model: Model B');
         expect(promptArg).toContain('Test Prompt');
+        // Should include format-preservation instruction
+        expect(promptArg).toContain('constrained format');
+    });
+
+    it('should respect topN parameter to limit responses', async () => {
+        (mockSummarizerProvider.streamResponse as Mock).mockImplementation(async (
+            _prompt: string,
+            _model: string,
+            _onChunk: (chunk: string) => void,
+            onComplete: (full: string, time: number, tokens?: number) => void
+        ) => {
+            onComplete('Top-2 Summary', 100, 10);
+            return Promise.resolve();
+        });
+
+        await strategy.generateConsensus(mockResponses, 2, 'Test Prompt');
+
+        const calls = (mockSummarizerProvider.streamResponse as Mock).mock.calls;
+        const promptArg = calls[0][0];
+
+        // Should include only top 2
+        expect(promptArg).toContain('Response 1:');
+        expect(promptArg).toContain('Response 2:');
+        expect(promptArg).not.toContain('Response 3:');
+        // Should NOT include model C content
+        expect(promptArg).not.toContain('Response C content');
     });
 });

--- a/packages/shared-utils/src/consensus/__tests__/councilUtils.test.ts
+++ b/packages/shared-utils/src/consensus/__tests__/councilUtils.test.ts
@@ -26,9 +26,10 @@ describe('councilUtils', () => {
             expect(result).toContain('AI is machine intelligence.');
         });
 
-        it('should instruct the model to identify flaws and strengths', () => {
+        it('should instruct the model to assess factual accuracy', () => {
             const result = buildCritiquePrompt('What is AI?', 'GPT-4o', 'AI is machine intelligence.');
-            expect(result.toLowerCase()).toMatch(/flaw|weakness|strength/);
+            expect(result).toContain('FACTUAL ASSESSMENT');
+            expect(result).toContain('VERDICT');
         });
     });
 
@@ -125,10 +126,12 @@ describe('councilUtils', () => {
             expect(result).toContain('AI mimics human cognition.');
         });
 
-        it('should include model names and ranks', () => {
+        it('should use anonymous labels instead of model names', () => {
             const result = buildCouncilSummaryPrompt('What is AI?', branches);
-            expect(result).toContain('GPT-4o');
-            expect(result).toContain('Claude');
+            expect(result).toContain('Response 1');
+            expect(result).toContain('Response 2');
+            expect(result).not.toContain('GPT-4o');
+            expect(result).not.toContain('Claude');
         });
     });
 
@@ -157,15 +160,21 @@ describe('councilUtils', () => {
             expect(result).toEqual({ isValid: false, reasoning: 'Weak argument.' });
         });
 
-        it('should default to valid for lorem ipsum / unparseable output', () => {
+        it('should abstain (null) for lorem ipsum / unparseable output', () => {
             const input = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
             const result = parseJudgmentVote(input);
-            expect(result).toEqual({ isValid: true, reasoning: '' });
+            expect(result).toEqual({ isValid: null, reasoning: '' });
         });
 
-        it('should default to valid for empty string', () => {
+        it('should abstain (null) for empty string', () => {
             const result = parseJudgmentVote('');
-            expect(result).toEqual({ isValid: true, reasoning: '' });
+            expect(result).toEqual({ isValid: null, reasoning: '' });
+        });
+
+        it('should extract JSON embedded in prose via regex fallback', () => {
+            const input = 'After careful consideration, {"isValid": false, "reasoning": "Factually wrong."} is my judgment.';
+            const result = parseJudgmentVote(input);
+            expect(result).toEqual({ isValid: false, reasoning: 'Factually wrong.' });
         });
 
         it('should handle JSON with extra whitespace', () => {

--- a/packages/shared-utils/src/consensus/__tests__/majorityVotingUtils.test.ts
+++ b/packages/shared-utils/src/consensus/__tests__/majorityVotingUtils.test.ts
@@ -14,25 +14,33 @@ describe('majorityVotingUtils', () => {
         { modelId: 'model-c', modelName: 'Model C', content: 'Response C' },
     ];
 
-    it('builds ranking prompt with source responses and original prompt', () => {
-        const prompt = buildMajorityRankingPrompt(responses, 'What is the answer?');
+    it('builds anonymous ranking prompt with source responses and original prompt', () => {
+        const { prompt, idMap } = buildMajorityRankingPrompt(responses, 'What is the answer?');
 
         expect(prompt).toContain('Original Question: What is the answer?');
-        expect(prompt).toContain('Model ID: model-a');
-        expect(prompt).toContain('Model Name: Model B');
+        expect(prompt).toContain('Response ID: Response-1');
+        expect(prompt).toContain('Response ID: Response-2');
+        expect(prompt).toContain('Response ID: Response-3');
+        // Should NOT contain real model IDs
+        expect(prompt).not.toContain('Model ID: model-a');
+        expect(prompt).not.toContain('Model Name: Model B');
         expect(prompt).toContain('Response:\nResponse C');
+        // idMap should map anonymous IDs back to real IDs
+        expect(idMap.get('Response-1')).toBe('model-a');
+        expect(idMap.get('Response-2')).toBe('model-b');
+        expect(idMap.get('Response-3')).toBe('model-c');
     });
 
-    it('builds synthesis prompt with majority anchor and ranked text', () => {
+    it('builds synthesis prompt with positional weighting instead of model identity', () => {
         const prompt = buildMajoritySynthesisPrompt({
             prompt: 'Original prompt',
-            rankedResponseText: '1. model-a\n2. model-b',
-            majorityModel: 'model-a',
+            rankedResponseText: '1. response-1\n2. response-2',
         });
 
         expect(prompt).toContain('Original Question: Original prompt');
-        expect(prompt).toContain('Treat the model with ID "model-a" as the majority anchor.');
-        expect(prompt).toContain('1. model-a\n2. model-b');
+        expect(prompt).toContain('Weight the first response most heavily');
+        expect(prompt).not.toContain('majority anchor');
+        expect(prompt).toContain('1. response-1\n2. response-2');
     });
 
     it('parses ranking JSON, clamps scores, and fills missing models', () => {
@@ -57,6 +65,29 @@ describe('majorityVotingUtils', () => {
             'model-c',
         ]);
         expect(parsed?.find((entry) => entry.modelId === 'model-c')?.eloScore).toBe(0);
+    });
+
+    it('resolves anonymous IDs back to real IDs via idMap', () => {
+        const idMap = new Map<string, string>([
+            ['Response-1', 'model-a'],
+            ['Response-2', 'model-b'],
+            ['Response-3', 'model-c'],
+        ]);
+        const parsed = parseMajorityVotingOutput(
+            JSON.stringify({
+                rankings: [
+                    { modelId: 'Response-2', alignmentScore: 90 },
+                    { modelId: 'Response-1', alignmentScore: 70 },
+                    { modelId: 'Response-3', alignmentScore: 50 },
+                ],
+            }),
+            responses,
+            idMap
+        );
+
+        expect(parsed).not.toBeNull();
+        expect(parsed).toHaveLength(3);
+        expect(parsed?.map((entry) => entry.modelId)).toEqual(['model-b', 'model-a', 'model-c']);
     });
 
     it('parses fenced JSON output and returns null for invalid output', () => {

--- a/packages/shared-utils/src/consensus/councilTypes.ts
+++ b/packages/shared-utils/src/consensus/councilTypes.ts
@@ -21,11 +21,11 @@ export interface Rebuttal {
     content: string;
 }
 
-/** One model's vote on whether a branch is valid */
+/** One model's vote on whether a branch is valid. null means abstain (unparseable). */
 export interface BranchVote {
     voterModelId: string;
     branchModelId: string;
-    isValid: boolean;
+    isValid: boolean | null;
     reasoning: string;
 }
 

--- a/packages/shared-utils/src/consensus/index.ts
+++ b/packages/shared-utils/src/consensus/index.ts
@@ -4,4 +4,5 @@ export * from './StandardConsensus';
 export * from './EloRankingConsensus';
 export * from './MajorityVotingConsensus';
 export * from './CouncilConsensus';
+export * from './SelfConsistencyConsensus';
 export * from './councilTypes';


### PR DESCRIPTION
## Summary

Implements 17 of 19 issues from the consensus strategy improvements plan, fixing critical bugs and improving prompt engineering across all 4 consensus strategies (standard, elo, majority, council).

**Key changes:**
- **Parser fix (Issue 1)**: `extractChoiceLetter()` now handles Markdown bold (`**A**`), underscore (`__D__`), extended phrasings ("correct/best option/answer is"), `A. [text]` format, and bare last-line letters
- **Cross-strategy (Issues 2-4)**: `temperature=0, seed=42` on all judge calls; chain-of-thought reasoning in judge prompts; format-preservation instruction added to Standard and Majority synthesis
- **Standard (Issues 5-6)**: `topN` parameter now respected (was `void topN`); model names anonymized as "Response 1/2/3"
- **ELO (Issues 7-8)**: Seed parameter for reproducibility; configurable `topK` via constructor
- **Majority (Issues 9-10)**: Anonymous IDs in ranking prompt (fixes hallucinated model IDs scored as 0); positional weighting replaces model identity in synthesis
- **Council (Issues 11-16)**: Fixed critical wiring bug where all 19 LLM calls went to same model via `perModelClients` parameter; rebuttal content now included in summary/ELO prompts; anonymous judge format; judgment fallback changed from valid→abstain (`isValid: null`); adversarial critique prompt; JSON regex fallback for prose-wrapped judgments
- **New strategy (Issue 17)**: `SelfConsistencyConsensus` - zero-LLM-call plurality voting using existing answer extractors

**Deferred to Wave 3:** Issues 18 (confidence-weighted synthesis) and 19 (mediation round).

**Stats:** 20 files changed, 430 insertions, 122 deletions. All 598 tests pass.

## Test plan
- [x] All existing tests pass (598/598)
- [x] New parser test cases for markdown bold/italic and extended phrasings
- [x] New SelfConsistencyConsensus tests (4 cases)
- [x] Updated tests for anonymized prompts in Standard, Majority, Council
- [x] Updated tests for null-vote abstain semantics in Council
- [x] TypeScript compiles clean across shared-utils, eval, and app packages
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)