### PR TITLE
fix(eval): handle markdown bold and extended phrasings in MCQ parser

### DIFF
--- a/packages/eval/src/lib/evaluators.test.ts
+++ b/packages/eval/src/lib/evaluators.test.ts
@@ -59,6 +59,42 @@ describe('extractChoiceLetter', () => {
   it('extracts "The correct answer is (D)"', () => {
     expect(extractChoiceLetter('The correct answer is (D)')).toBe('D');
   });
+
+  it('extracts markdown bold **A**', () => {
+    expect(extractChoiceLetter('The answer is **A**')).toBe('A');
+  });
+
+  it('extracts markdown underscore __D__', () => {
+    expect(extractChoiceLetter('The answer is __D__')).toBe('D');
+  });
+
+  it('extracts "The correct option is A"', () => {
+    expect(extractChoiceLetter('The correct option is A')).toBe('A');
+  });
+
+  it('extracts "The best answer is B"', () => {
+    expect(extractChoiceLetter('The best answer is B')).toBe('B');
+  });
+
+  it('extracts "The best option is C"', () => {
+    expect(extractChoiceLetter('The best option is C')).toBe('C');
+  });
+
+  it('extracts "A. Bananas are yellow" format', () => {
+    expect(extractChoiceLetter('A. Bananas are yellow')).toBe('A');
+  });
+
+  it('extracts bare letter on last line', () => {
+    expect(extractChoiceLetter('After analysis, I believe the answer is:\nB')).toBe('B');
+  });
+
+  it('extracts single bold letter **C**', () => {
+    expect(extractChoiceLetter('**C**')).toBe('C');
+  });
+
+  it('extracts italic *A*', () => {
+    expect(extractChoiceLetter('The answer is *A*')).toBe('A');
+  });
 });
 
 describe('NumericEvaluator', () => {


### PR DESCRIPTION
## Summary

`extractChoiceLetter()` was returning `null` for common LLM output formats, inflating failure rates for strategies whose synthesis used markdown formatting (especially Gemini models):

- Markdown bold `**A**` and italic `*A*` / underscore `__D__`
- "The correct/best option is A" phrasings
- "A. [option text]" MCQ format
- Bare letter on last line after reasoning

The fix strips markdown markers before pattern matching and adds the missing patterns.

**This fixes the measurement tool itself**, so it must land before we can reliably evaluate any other consensus strategy changes.

## Next step

After merge, re-run eval to get a clean baseline with the fixed parser. Then apply strategy changes one at a time, measuring each.

## Test plan
- [x] 9 new test cases covering all missing formats
- [x] All 27 parser tests pass
- [x] All 428 eval tests pass
- [x] All 165 shared-utils tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)