### PR TITLE
feat(eval): tune concurrency to 40/60 and reduce sample to 30

### DIFF
--- a/packages/eval/src/commands/quickEval.test.ts
+++ b/packages/eval/src/commands/quickEval.test.ts
@@ -31,11 +31,11 @@ describe('quickEval', () => {
     expect(opts.judgeModel).toBe('google:gemini-2.5-flash');
     expect(opts.ensemble).toBe('5');
     expect(opts.temperature).toBe('0.7');
-    expect(opts.sample).toBe('50');
+    expect(opts.sample).toBe('30');
     expect(opts.mode).toBe('free');
     expect(opts.cache).toBe(true);
     expect(opts.parallel).toBe(true);
-    expect(opts.concurrency).toBe('50');
+    expect(opts.concurrency).toBe('40');
   });
 
   it('parses custom options', () => {

--- a/packages/eval/src/commands/quickEval.ts
+++ b/packages/eval/src/commands/quickEval.ts
@@ -18,7 +18,7 @@ const DEFAULT_MODEL = 'google:gemini-2.5-flash-lite';
 const DEFAULT_JUDGE_MODEL = 'google:gemini-2.5-flash';
 const DEFAULT_ENSEMBLE_SIZE = 5;
 const DEFAULT_TEMPERATURE = 0.7;
-const DEFAULT_SAMPLE = 50;
+const DEFAULT_SAMPLE = 30;
 const DEFAULT_DATASETS: BenchmarkDatasetName[] = [
   'gsm8k', 'truthfulqa', 'gpqa', 'hle', 'math500',
   'mmlu_pro', 'simpleqa', 'arc', 'hellaswag', 'hallumix',
@@ -72,7 +72,7 @@ export function createQuickEvalCommand(): Command {
     .option('--no-parallel', 'Run datasets sequentially instead of in parallel.')
     .option('--baseline <path>', 'Path to baseline JSON. Saves results and fails on regression.')
     .option('--significance <alpha>', 'Significance level for regression detection (0 < alpha < 1).', '0.10')
-    .option('--concurrency <count>', 'Initial max concurrent questions (auto-adapts via AIMD).', '50')
+    .option('--concurrency <count>', 'Initial max concurrent questions (auto-adapts via AIMD).', '40')
     .action(async (options: QuickEvalOptions) => {
       const { provider, model: modelName } = parseModelSpec(options.model);
       const model = options.model;
@@ -117,7 +117,7 @@ export function createQuickEvalCommand(): Command {
       registerProviders(registry, [...providers], mode);
 
       const monitor = new SystemMonitor();
-      const limiter = new ConcurrencyLimiter({ initial: initialConcurrency, min: 1, max: 500, monitor });
+      const limiter = new ConcurrencyLimiter({ initial: initialConcurrency, min: 1, max: 60, monitor });
 
       const startTime = Date.now();
       const log = (s: string) => process.stderr.write(s);


### PR DESCRIPTION
## Summary
- Set default concurrency to 40 (from 50) with max cap at 60, based on observed API rate-limit ceiling of ~70-87 concurrent questions during CI runs
- Reduce default sample size from 50 to 30 for faster CI runs

## Context
Analysis of two CI runs (c=10 and c=50) showed the Gemini API rate-limits at ~70-87 concurrent questions. Both runs converged to the same ~1.3-1.5/s throughput via AIMD. Starting at 40 with a max of 60 avoids unnecessary 429s during ramp-up while staying close to the effective ceiling.

## Test plan
- [x] All unit tests pass (449 passed)
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)