### PR TITLE
fix(eval): skip PR comment when CI run is cancelled

### DIFF
--- a/.github/workflows/eval-ci.yml
+++ b/.github/workflows/eval-ci.yml
@@ -145,7 +145,7 @@ jobs:
           cat eval-results.txt
 
       - name: Upload eval results
-        if: always() && steps.check-keys.outputs.keys_available == 'true'
+        if: "!cancelled() && steps.check-keys.outputs.keys_available == 'true'"
         uses: actions/upload-artifact@v4
         with:
           name: eval-${{ matrix.strategy }}-results
@@ -166,7 +166,7 @@ jobs:
   eval-report:
     name: Eval Report
     needs: [detect-changes, eval-strategy]
-    if: always() && github.event_name == 'pull_request'
+    if: "!cancelled() && github.event_name == 'pull_request'"
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Summary
- Replace `always()` with `!cancelled()` on the artifact upload step and the eval-report job
- Cancelled runs (from pushing a new commit) no longer post empty eval comments on the PR

## Test plan
- [ ] Push two commits in quick succession to a PR touching `packages/eval/`
- [ ] Verify the cancelled run does not post an empty comment
- [ ] Verify a completed run still posts the full eval report

🤖 Generated with [Claude Code](https://claude.com/claude-code)