### PR TITLE
feat: add DeepSeek as a provider

### DIFF
--- a/packages/app/src/app/config/hooks/useApiKeyAutoHide.ts
+++ b/packages/app/src/app/config/hooks/useApiKeyAutoHide.ts
@@ -3,7 +3,7 @@ import { useStore } from '~/store';
 import type { Provider } from '@/components/molecules/ApiKeyInput';
 
 const AUTO_HIDE_DELAY_MS = 10_000;
-const PROVIDERS: Provider[] = ['openai', 'anthropic', 'google', 'xai'];
+const PROVIDERS: Provider[] = ['openai', 'anthropic', 'google', 'xai', 'deepseek'];
 
 /**
  * Auto-hides revealed API keys after a period of inactivity and

--- a/packages/app/src/app/config/hooks/useConfigPage.ts
+++ b/packages/app/src/app/config/hooks/useConfigPage.ts
@@ -13,7 +13,7 @@ import { toError } from '~/lib/errors';
 import { getHydratedStatus } from '~/lib/providerStatus';
 import { logger } from '~/lib/logger';
 
-const PROVIDERS: Provider[] = ['openai', 'anthropic', 'google', 'xai'];
+const PROVIDERS: Provider[] = ['openai', 'anthropic', 'google', 'xai', 'deepseek'];
 
 export function useConfigPage() {
     const { t } = useTranslation('common');
@@ -40,6 +40,7 @@ export function useConfigPage() {
         anthropic: null,
         google: null,
         xai: null,
+        deepseek: null,
     });
     const { resetAutoHideTimer } = useApiKeyAutoHide();
     const [webCryptoSupported, setWebCryptoSupported] = useState(true);
@@ -63,6 +64,7 @@ export function useConfigPage() {
             anthropic: apiKeys.anthropic?.status ?? 'idle',
             google: apiKeys.google?.status ?? 'idle',
             xai: apiKeys.xai?.status ?? 'idle',
+            deepseek: apiKeys.deepseek?.status ?? 'idle',
         }),
         [apiKeys],
     );

--- a/packages/app/src/app/ensemble/__tests__/ensemble-integration.test.tsx
+++ b/packages/app/src/app/ensemble/__tests__/ensemble-integration.test.tsx
@@ -33,6 +33,7 @@ describe('Ensemble Page - Model Selection Integration', () => {
         anthropic: { key: '', encrypted: null, visible: false, status: 'idle' },
         google: { key: '', encrypted: null, visible: false, status: 'idle' },
         xai: { key: '', encrypted: null, visible: false, status: 'idle' },
+        deepseek: { key: '', encrypted: null, visible: false, status: 'idle' },
       },
       encryptionInitialized: true,
       selectedModels: [],

--- a/packages/app/src/app/ensemble/hooks/useApiKeyModal.ts
+++ b/packages/app/src/app/ensemble/hooks/useApiKeyModal.ts
@@ -39,7 +39,7 @@ export function useApiKeyModal({
         provider: selectedProvider,
         label: `${selectedProvider.charAt(0).toUpperCase() + selectedProvider.slice(1)} API Key`,
         value: safeApiKeys[selectedProvider]?.key ?? '',
-        placeholder: selectedProvider === 'openai' ? 'sk-...' : selectedProvider === 'anthropic' ? 'sk-ant-...' : selectedProvider === 'google' ? 'AIza...' : 'xai-...',
+        placeholder: selectedProvider === 'openai' ? 'sk-...' : selectedProvider === 'anthropic' ? 'sk-ant-...' : selectedProvider === 'google' ? 'AIza...' : selectedProvider === 'deepseek' ? 'sk-...' : 'xai-...',
         helperText:
           hydratedStatuses[selectedProvider] === 'valid'
             ? 'API key configured'

--- a/packages/app/src/app/ensemble/hooks/useEnsemblePage.ts
+++ b/packages/app/src/app/ensemble/hooks/useEnsemblePage.ts
@@ -65,6 +65,7 @@ export function useEnsemblePage() {
             anthropic: safeApiKeys.anthropic?.status ?? 'idle',
             google: safeApiKeys.google?.status ?? 'idle',
             xai: safeApiKeys.xai?.status ?? 'idle',
+            deepseek: safeApiKeys.deepseek?.status ?? 'idle',
         }),
         [safeApiKeys],
     );
@@ -100,6 +101,7 @@ export function useEnsemblePage() {
         anthropic: null,
         google: null,
         xai: null,
+        deepseek: null,
     });
 
     // Handler for validation status changes

--- a/packages/app/src/app/ensemble/page.constants.ts
+++ b/packages/app/src/app/ensemble/page.constants.ts
@@ -2,7 +2,7 @@ import type { Provider } from '@/components/molecules/ApiKeyInput';
 import type { Preset } from '@/components/organisms/EnsembleSidebar';
 import type { StoreState } from '~/store';
 
-export const PROVIDERS: Provider[] = ['openai', 'anthropic', 'google', 'xai'];
+export const PROVIDERS: Provider[] = ['openai', 'anthropic', 'google', 'xai', 'deepseek'];
 
 export const PRESETS: Preset[] = [
   {
@@ -36,6 +36,7 @@ export const EMPTY_API_KEYS: StoreState['apiKeys'] = {
   anthropic: null,
   google: null,
   xai: null,
+  deepseek: null,
 };
 
 export const DEFAULT_ENSEMBLE_NAME = '';

--- a/packages/app/src/app/review/hooks/useConsensusGeneration.ts
+++ b/packages/app/src/app/review/hooks/useConsensusGeneration.ts
@@ -138,7 +138,7 @@ export function useConsensusGeneration() {
     };
 }
 
-const VALID_PROVIDERS: ProviderName[] = ['openai', 'anthropic', 'google', 'xai'];
+const VALID_PROVIDERS: ProviderName[] = ['openai', 'anthropic', 'google', 'xai', 'deepseek'];
 
 function validateProviderName(provider: string): ProviderName {
     if (VALID_PROVIDERS.includes(provider as ProviderName)) {

--- a/packages/app/src/lib/__tests__/providerStatus.test.ts
+++ b/packages/app/src/lib/__tests__/providerStatus.test.ts
@@ -7,6 +7,7 @@ const statuses: Record<Provider, ValidationStatus> = {
   anthropic: 'invalid',
   google: 'validating',
   xai: 'idle',
+  deepseek: 'idle',
 };
 
 describe('provider status utilities', () => {
@@ -17,6 +18,7 @@ describe('provider status utilities', () => {
       anthropic: 'idle',
       google: 'idle',
       xai: 'idle',
+      deepseek: 'idle',
     });
   });
 

--- a/packages/app/src/lib/modelModalities.ts
+++ b/packages/app/src/lib/modelModalities.ts
@@ -55,6 +55,8 @@ function supportsImage(provider: ProviderName, identifier: string): boolean {
       return identifier.startsWith('gemini-');
     case 'xai':
       return identifier.includes('vision') || identifier.includes('image');
+    case 'deepseek':
+      return false;
     default:
       return false;
   }

--- a/packages/app/src/lib/models.ts
+++ b/packages/app/src/lib/models.ts
@@ -87,4 +87,18 @@ export const FALLBACK_MODELS: Model[] = [
     name: 'Claude 3 Opus',
     modalities: ['text', 'image'],
   },
+
+  // DeepSeek
+  {
+    id: 'deepseek-chat',
+    provider: 'deepseek',
+    name: 'DeepSeek Chat',
+    modalities: ['text'],
+  },
+  {
+    id: 'deepseek-reasoner',
+    provider: 'deepseek',
+    name: 'DeepSeek Reasoner',
+    modalities: ['text'],
+  },
 ];

--- a/packages/app/src/lib/providerStatus.ts
+++ b/packages/app/src/lib/providerStatus.ts
@@ -6,6 +6,7 @@ const DEFAULT_STATUS: Record<Provider, ValidationStatus> = {
   anthropic: 'idle',
   google: 'idle',
   xai: 'idle',
+  deepseek: 'idle',
 };
 
 const READY_STATUS: Record<Provider, string> = {
@@ -13,6 +14,7 @@ const READY_STATUS: Record<Provider, string> = {
   anthropic: 'Ready',
   google: 'Ready',
   xai: 'Ready',
+  deepseek: 'Ready',
 };
 
 export function getHydratedStatus(
@@ -53,5 +55,6 @@ export function createProviderStatusLabels(options: {
     anthropic: mapStatusToLabel(statuses.anthropic),
     google: mapStatusToLabel(statuses.google),
     xai: mapStatusToLabel(statuses.xai),
+    deepseek: mapStatusToLabel(statuses.deepseek),
   };
 }

--- a/packages/app/src/providers/index.ts
+++ b/packages/app/src/providers/index.ts
@@ -5,7 +5,7 @@ import {
 } from '@ensemble-ai/shared-utils/providers';
 import { useStore } from '~/store';
 
-const PROVIDERS: ProviderName[] = ['openai', 'anthropic', 'google', 'xai'];
+const PROVIDERS: ProviderName[] = ['openai', 'anthropic', 'google', 'xai', 'deepseek'];
 
 export function initializeProviders(): void {
   const registry = ProviderRegistry.getInstance();

--- a/packages/app/src/store/__tests__/apiKeySlice.test.ts
+++ b/packages/app/src/store/__tests__/apiKeySlice.test.ts
@@ -85,6 +85,7 @@ describe('apiKeySlice', () => {
         anthropic: null,
         google: null,
         xai: null,
+        deepseek: null,
       },
       encryptionInitialized: true,
     });

--- a/packages/app/src/store/index.ts
+++ b/packages/app/src/store/index.ts
@@ -52,6 +52,7 @@ const sanitizeStateForPersist = (state: StoreState): StoreState => {
     'anthropic',
     'google',
     'xai',
+    'deepseek',
   ];
 
   sanitized.apiKeys = {
@@ -59,6 +60,7 @@ const sanitizeStateForPersist = (state: StoreState): StoreState => {
     anthropic: null,
     google: null,
     xai: null,
+    deepseek: null,
   };
 
   providers.forEach((provider) => {

--- a/packages/app/src/store/slices/apiKeySlice.ts
+++ b/packages/app/src/store/slices/apiKeySlice.ts
@@ -25,6 +25,7 @@ export interface ApiKeySlice {
     anthropic: ApiKeyData | null;
     google: ApiKeyData | null;
     xai: ApiKeyData | null;
+    deepseek: ApiKeyData | null;
   };
   encryptionInitialized: boolean;
 
@@ -47,6 +48,7 @@ export const createApiKeySlice: StateCreator<ApiKeySlice> = (set, get) => ({
     anthropic: null,
     google: null,
     xai: null,
+    deepseek: null,
   },
   encryptionInitialized: false,
 
@@ -56,7 +58,7 @@ export const createApiKeySlice: StateCreator<ApiKeySlice> = (set, get) => ({
       return;
     }
 
-    const providers: ProviderType[] = ['openai', 'anthropic', 'google', 'xai'];
+    const providers: ProviderType[] = ['openai', 'anthropic', 'google', 'xai', 'deepseek'];
 
     await Promise.all(
       providers.map(async (provider) => {
@@ -174,7 +176,7 @@ export const createApiKeySlice: StateCreator<ApiKeySlice> = (set, get) => ({
 
   hideAllApiKeys: () => {
     set((state) => {
-      const providers: ProviderType[] = ['openai', 'anthropic', 'google', 'xai'];
+      const providers: ProviderType[] = ['openai', 'anthropic', 'google', 'xai', 'deepseek'];
       const updatedKeys = { ...state.apiKeys };
       for (const provider of providers) {
         const entry = updatedKeys[provider];
@@ -198,6 +200,7 @@ export const createApiKeySlice: StateCreator<ApiKeySlice> = (set, get) => ({
         anthropic: null,
         google: null,
         xai: null,
+        deepseek: null,
       },
       encryptionInitialized: false,
     });

--- a/packages/app/src/store/slices/ensembleSlice.ts
+++ b/packages/app/src/store/slices/ensembleSlice.ts
@@ -7,7 +7,7 @@
 import type { StateCreator } from 'zustand';
 import type { ConsensusMethod } from '@ensemble-ai/shared-utils/consensus';
 
-export type ProviderType = 'openai' | 'anthropic' | 'google' | 'xai';
+export type ProviderType = 'openai' | 'anthropic' | 'google' | 'xai' | 'deepseek';
 
 export interface ModelSelection {
   id: string;

--- a/packages/app/tests/unit/lib/providerStatus.test.ts
+++ b/packages/app/tests/unit/lib/providerStatus.test.ts
@@ -7,6 +7,7 @@ const baseStatuses: Record<Provider, 'idle' | 'invalid' | 'valid' | 'validating'
   anthropic: 'valid',
   google: 'validating',
   xai: 'idle',
+  deepseek: 'idle',
 };
 
 describe('createProviderStatusLabels', () => {
@@ -22,6 +23,7 @@ describe('createProviderStatusLabels', () => {
       anthropic: 'Ready',
       google: 'Ready',
       xai: 'Ready',
+      deepseek: 'Ready',
     });
   });
 

--- a/packages/app/tests/unit/lib/validation.test.ts
+++ b/packages/app/tests/unit/lib/validation.test.ts
@@ -87,6 +87,7 @@ describe('createDebouncedValidator', () => {
       anthropic: null,
       google: null,
       xai: null,
+      deepseek: null,
     } as Record<Provider, NodeJS.Timeout | null>,
   };
 
@@ -97,6 +98,7 @@ describe('createDebouncedValidator', () => {
       anthropic: null,
       google: null,
       xai: null,
+      deepseek: null,
     };
   });
 

--- a/packages/component-library/src/components/molecules/ApiKeyInput/ApiKeyInput.tsx
+++ b/packages/component-library/src/components/molecules/ApiKeyInput/ApiKeyInput.tsx
@@ -7,7 +7,7 @@ import { LoadingSpinner } from '../../atoms/LoadingSpinner';
 import { InlineAlert } from '../../atoms/InlineAlert';
 import { cn } from '@/lib/utils';
 
-export type Provider = 'openai' | 'anthropic' | 'google' | 'xai';
+export type Provider = 'openai' | 'anthropic' | 'google' | 'xai' | 'deepseek';
 export type ValidationStatus = 'idle' | 'validating' | 'valid' | 'invalid';
 
 export interface ApiKeyInputProps {

--- a/packages/component-library/src/components/molecules/ModelCard/ModelCard.tsx
+++ b/packages/component-library/src/components/molecules/ModelCard/ModelCard.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent } from '../../atoms/Card';
 import { Badge } from '../../atoms/Badge';
 import { cn } from '@/lib/utils';
 
-export type Provider = 'openai' | 'anthropic' | 'google' | 'xai';
+export type Provider = 'openai' | 'anthropic' | 'google' | 'xai' | 'deepseek';
 export type { ModelModality };
 
 export interface ModelCardProps {
@@ -45,6 +45,10 @@ const PROVIDER_CONFIG = {
   xai: {
     name: 'XAI',
     icon: '🚀',
+  },
+  deepseek: {
+    name: 'DeepSeek',
+    icon: '🐋',
   },
 } as const;
 

--- a/packages/component-library/src/components/molecules/ResponseCard/ResponseCard.tsx
+++ b/packages/component-library/src/components/molecules/ResponseCard/ResponseCard.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { ChevronDown, ChevronUp, Copy } from 'lucide-react';
 import { Markdown } from '../../atoms/Markdown';
 
-export type Provider = 'openai' | 'anthropic' | 'google' | 'xai';
+export type Provider = 'openai' | 'anthropic' | 'google' | 'xai' | 'deepseek';
 export type ResponseStatus = 'streaming' | 'complete' | 'error';
 export type ResponseType = 'ai' | 'manual';
 
@@ -50,6 +50,7 @@ export const PROVIDER_NAMES = {
   anthropic: 'Anthropic',
   google: 'Google',
   xai: 'XAI',
+  deepseek: 'DeepSeek',
 } as const;
 
 /**

--- a/packages/component-library/src/components/organisms/ModelSelectionList/ModelSelectionList.tsx
+++ b/packages/component-library/src/components/organisms/ModelSelectionList/ModelSelectionList.tsx
@@ -36,6 +36,7 @@ const PROVIDER_LABELS: Record<Provider, string> = {
   anthropic: 'Anthropic',
   google: 'Google',
   xai: 'XAI',
+  deepseek: 'DeepSeek',
 };
 
 /**
@@ -82,6 +83,7 @@ export const ModelSelectionList = React.forwardRef<HTMLDivElement, ModelSelectio
         anthropic: [],
         google: [],
         xai: [],
+        deepseek: [],
       };
 
       models.forEach((model) => {

--- a/packages/consensus-core/src/types.d.ts
+++ b/packages/consensus-core/src/types.d.ts
@@ -23,7 +23,7 @@ export interface StructuredResponse<T> {
     tokenCount?: number;
 }
 export type ModelModality = 'text' | 'image' | 'audio' | 'video';
-export type ProviderName = 'openai' | 'anthropic' | 'google' | 'xai';
+export type ProviderName = 'openai' | 'anthropic' | 'google' | 'xai' | 'deepseek';
 export interface ModelMetadata {
     id: string;
     name: string;

--- a/packages/consensus-core/src/types.ts
+++ b/packages/consensus-core/src/types.ts
@@ -41,7 +41,7 @@ export interface StructuredResponse<T> {
 
 export type ModelModality = 'text' | 'image' | 'audio' | 'video';
 
-export type ProviderName = 'openai' | 'anthropic' | 'google' | 'xai';
+export type ProviderName = 'openai' | 'anthropic' | 'google' | 'xai' | 'deepseek';
 
 export interface ModelMetadata {
   id: string;

--- a/packages/eval/src/lib/ensembleRunner.test.ts
+++ b/packages/eval/src/lib/ensembleRunner.test.ts
@@ -62,6 +62,7 @@ describe('EnsembleRunner', () => {
         anthropic: anthropicProvider,
         google: openaiProvider,
         xai: openaiProvider,
+        deepseek: openaiProvider,
       }),
       'mock',
     );
@@ -106,6 +107,7 @@ describe('EnsembleRunner', () => {
         anthropic: provider,
         google: provider,
         xai: provider,
+        deepseek: provider,
       }),
       'mock',
       { requestDelayMs: 25 },
@@ -135,6 +137,7 @@ describe('EnsembleRunner', () => {
         anthropic: provider,
         google: provider,
         xai: provider,
+        deepseek: provider,
       }),
       'mock',
       { temperature: 0 },
@@ -160,6 +163,7 @@ describe('EnsembleRunner', () => {
         anthropic: provider,
         google: provider,
         xai: provider,
+        deepseek: provider,
       }),
       'mock',
     );
@@ -188,6 +192,7 @@ describe('EnsembleRunner', () => {
         anthropic: provider,
         google: provider,
         xai: provider,
+        deepseek: provider,
       }),
       'mock',
       { retry: { maxRetries: 3, baseDelayMs: 1, maxJitterMs: 0 } },
@@ -218,6 +223,7 @@ describe('EnsembleRunner', () => {
         anthropic: provider,
         google: provider,
         xai: provider,
+        deepseek: provider,
       }),
       'mock',
       { retry: { maxRetries: 3, baseDelayMs: 1, maxJitterMs: 0 } },
@@ -263,6 +269,7 @@ describe('EnsembleRunner', () => {
         anthropic: provider,
         google: provider,
         xai: provider,
+        deepseek: provider,
       }),
       'mock',
       {
@@ -305,6 +312,7 @@ describe('EnsembleRunner', () => {
         anthropic: provider,
         google: provider,
         xai: provider,
+        deepseek: provider,
       }),
       'mock',
     );

--- a/packages/eval/src/lib/modelSpecs.ts
+++ b/packages/eval/src/lib/modelSpecs.ts
@@ -1,6 +1,6 @@
 import type { EvalProvider, ModelSpec } from '../types.js';
 
-const VALID_PROVIDERS: EvalProvider[] = ['openai', 'anthropic', 'google', 'xai'];
+const VALID_PROVIDERS: EvalProvider[] = ['openai', 'anthropic', 'google', 'xai', 'deepseek'];
 const VALID_PROVIDER_SET = new Set<EvalProvider>(VALID_PROVIDERS);
 
 export function explodeList(values: string[]): string[] {

--- a/packages/eval/src/lib/providers.ts
+++ b/packages/eval/src/lib/providers.ts
@@ -10,6 +10,7 @@ const API_KEY_ENV: Record<EvalProvider, string> = {
   anthropic: 'ANTHROPIC_API_KEY',
   google: 'GOOGLE_API_KEY',
   xai: 'XAI_API_KEY',
+  deepseek: 'DEEPSEEK_API_KEY',
 };
 
 export function getApiKeyForProvider(provider: EvalProvider): string | null {

--- a/packages/shared-utils/src/providers/clients/deepseek/FreeDeepSeekClient.ts
+++ b/packages/shared-utils/src/providers/clients/deepseek/FreeDeepSeekClient.ts
@@ -1,0 +1,126 @@
+import OpenAI from 'openai';
+import { BaseFreeClient, type StreamOptions, type StructuredOptions } from '../base/BaseFreeClient';
+import type { StructuredResponse, ValidationResult } from '../../types';
+
+export class FreeDeepSeekClient extends BaseFreeClient {
+  private createClient(apiKey: string) {
+    return new OpenAI({
+      apiKey,
+      baseURL: 'https://api.deepseek.com',
+      dangerouslyAllowBrowser: true,
+    });
+  }
+
+  async validateApiKey(apiKey: string): Promise<ValidationResult> {
+    if (!apiKey || apiKey.trim().length === 0) {
+      return { valid: false, error: 'API key is required.' };
+    }
+
+    try {
+      const client = this.createClient(apiKey);
+      await client.models.list();
+      return { valid: true };
+    } catch (error) {
+      return { valid: false, error: error instanceof Error ? error.message : 'Invalid DeepSeek API key.' };
+    }
+  }
+
+  protected async fetchTextModels(_apiKey: string): Promise<string[]> {
+    return ['deepseek-chat', 'deepseek-reasoner'];
+  }
+
+  protected override async generateStructuredWithProvider<T>(
+    options: StructuredOptions,
+  ): Promise<StructuredResponse<T>> {
+    const client = this.createClient(options.apiKey);
+    const startTime = Date.now();
+
+    const response = await client.chat.completions.create({
+      model: options.model,
+      messages: [{ role: 'user', content: options.prompt }],
+      response_format: {
+        type: 'json_schema' as const,
+        json_schema: {
+          name: options.schema.name,
+          strict: true,
+          schema: options.schema.schema,
+        },
+      },
+      ...(options.options?.temperature !== undefined && {
+        temperature: options.options.temperature,
+      }),
+    });
+
+    const raw = response.choices[0]?.message?.content ?? '';
+    if (!raw) {
+      throw new Error('DeepSeek returned empty structured output');
+    }
+    const parsed = JSON.parse(raw) as T;
+    const tokenCount = response.usage?.total_tokens;
+
+    return {
+      parsed,
+      raw,
+      responseTimeMs: Date.now() - startTime,
+      ...(tokenCount ? { tokenCount } : {}),
+    };
+  }
+
+  protected override async streamWithProvider(options: StreamOptions): Promise<void> {
+    const startTime = Date.now();
+    let fullResponse = '';
+    let tokenCount = 0;
+
+    try {
+      const client = this.createClient(options.apiKey);
+
+      const stream = await client.chat.completions.create({
+        model: options.model,
+        stream: true,
+        messages: [{ role: 'user', content: options.prompt }],
+        stream_options: { include_usage: true },
+        ...(options.streamOptions?.temperature !== undefined && {
+          temperature: options.streamOptions.temperature,
+        }),
+        ...(options.streamOptions?.seed !== undefined && {
+          seed: options.streamOptions.seed,
+        }),
+      });
+
+      for await (const chunk of stream as AsyncIterable<{
+        choices?: { delta?: { content?: unknown }; finish_reason?: string | null }[];
+        usage?: { total_tokens?: number };
+      }>) {
+        if (chunk.usage?.total_tokens) {
+          tokenCount = chunk.usage.total_tokens;
+        }
+
+        const choice = chunk.choices?.[0];
+        const deltaContent = choice?.delta?.content;
+
+        if (typeof deltaContent === 'string') {
+          fullResponse += deltaContent;
+          options.onChunk(deltaContent);
+        } else if (Array.isArray(deltaContent)) {
+          for (const piece of deltaContent) {
+            if (typeof piece === 'string') {
+              fullResponse += piece;
+              options.onChunk(piece);
+            } else if (piece && typeof (piece as { text?: string }).text === 'string') {
+              const text = (piece as { text?: string }).text as string;
+              fullResponse += text;
+              options.onChunk(text);
+            }
+          }
+        }
+      }
+
+      options.onComplete(fullResponse, Date.now() - startTime, tokenCount > 0 ? tokenCount : undefined);
+    } catch (error) {
+      const errorMessage = error instanceof Error
+        ? error.message
+        : String(error);
+      options.onError(new Error(`DeepSeek API error: ${errorMessage}`));
+    }
+  }
+}

--- a/packages/shared-utils/src/providers/clients/mock/MockProviderClient.ts
+++ b/packages/shared-utils/src/providers/clients/mock/MockProviderClient.ts
@@ -215,6 +215,22 @@ export class MockProviderClient implements AIProvider {
         costPer1kTokens: 0.0002,
         modalities: ['text'],
       },
+      {
+        id: 'deepseek-chat',
+        name: 'DeepSeek Chat',
+        provider: 'deepseek',
+        contextWindow: 128000,
+        costPer1kTokens: 0.00014,
+        modalities: ['text'],
+      },
+      {
+        id: 'deepseek-reasoner',
+        name: 'DeepSeek Reasoner',
+        provider: 'deepseek',
+        contextWindow: 128000,
+        costPer1kTokens: 0.00055,
+        modalities: ['text'],
+      },
     ];
 
     if (this.config.providerFilter) {

--- a/packages/shared-utils/src/providers/factories/createProviderClient.ts
+++ b/packages/shared-utils/src/providers/factories/createProviderClient.ts
@@ -4,6 +4,7 @@ import { FreeOpenAIClient } from '../clients/openai/FreeOpenAIClient';
 import { FreeAnthropicClient } from '../clients/anthropic/FreeAnthropicClient';
 import { FreeGoogleClient } from '../clients/google/FreeGoogleClient';
 import { FreeXAIClient } from '../clients/xai/FreeXAIClient';
+import { FreeDeepSeekClient } from '../clients/deepseek/FreeDeepSeekClient';
 
 interface CreateProviderClientOptions {
   provider: ProviderName;
@@ -34,6 +35,8 @@ export function createProviderClient({
         return new FreeGoogleClient(provider, getApiKey);
       case 'xai':
         return new FreeXAIClient(provider, getApiKey);
+      case 'deepseek':
+        return new FreeDeepSeekClient(provider, getApiKey);
       default:
         throw new Error(`Unsupported provider: ${provider}`);
     }

--- a/packages/shared-utils/src/providers/index.ts
+++ b/packages/shared-utils/src/providers/index.ts
@@ -6,3 +6,4 @@ export * from './clients/openai/FreeOpenAIClient';
 export * from './clients/anthropic/FreeAnthropicClient';
 export * from './clients/google/FreeGoogleClient';
 export * from './clients/xai/FreeXAIClient';
+export * from './clients/deepseek/FreeDeepSeekClient';

--- a/packages/shared-utils/src/providers/types.ts
+++ b/packages/shared-utils/src/providers/types.ts
@@ -1,4 +1,4 @@
-export type ProviderName = 'openai' | 'anthropic' | 'google' | 'xai';
+export type ProviderName = 'openai' | 'anthropic' | 'google' | 'xai' | 'deepseek';
 export type ProviderMode = 'mock' | 'free' | 'pro';
 export type ModelModality = 'text' | 'image' | 'audio' | 'video';
 


### PR DESCRIPTION
## Summary

- Adds DeepSeek V3 as a fifth AI provider across the entire monorepo (shared-utils, consensus-core, eval, component-library, app)
- DeepSeek offers significantly cheaper pricing ($0.14/$0.28 per M tokens, cache hits at $0.028/M) — ideal for reducing eval and development costs
- Uses OpenAI SDK with custom `baseURL` (same pattern as XAI client), supports `json_schema` structured output and streaming
- Models: `deepseek-chat` (general) and `deepseek-reasoner` (chain-of-thought)

## Changes

| Package | Changes |
|---------|---------|
| `shared-utils` | New `FreeDeepSeekClient`, updated `ProviderName` type, factory, exports, mock models |
| `consensus-core` | Updated `ProviderName` union type |
| `eval` | Added `DEEPSEEK_API_KEY` env mapping, `VALID_PROVIDERS`, test fixtures |
| `component-library` | Updated `Provider` types, `ModelCard` config, `ResponseCard` names, `ModelSelectionList` labels |
| `app` | Updated store slices, provider status, fallback models, model modalities, config/ensemble hooks, all test fixtures |

## Test plan

- [x] All typechecks pass (`npm run typecheck` across all packages)
- [x] All shared-utils tests pass
- [x] All eval tests pass (453 pass, 3 pre-existing flaky HuggingFace loader timeouts)
- [x] All app tests pass
- [x] All component-library tests pass
- [x] Pre-commit hooks pass (lint, typecheck, build, tests, FTA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)