### PR TITLE
fix(ci): fix two failures breaking main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build consensus packages
+        run: |
+          npm run build --workspace=packages/consensus-core
+          npm run build --workspace=packages/consensus-standard
+          npm run build --workspace=packages/consensus-elo
+          npm run build --workspace=packages/consensus-majority
+          npm run build --workspace=packages/consensus-council
+
       - name: Build shared-utils
         run: npm run build --workspace=packages/shared-utils
 

--- a/.github/workflows/eval-post-merge.yml
+++ b/.github/workflows/eval-post-merge.yml
@@ -64,6 +64,15 @@ jobs:
             eval-baseline-${{ hashFiles('packages/eval/src/lib/baselineCache.ts') }}-
             eval-baseline-
 
+      - name: Build consensus packages
+        if: steps.check-keys.outputs.keys_available == 'true'
+        run: |
+          npm run build --workspace=packages/consensus-core
+          npm run build --workspace=packages/consensus-standard
+          npm run build --workspace=packages/consensus-elo
+          npm run build --workspace=packages/consensus-majority
+          npm run build --workspace=packages/consensus-council
+
       - name: Build shared-utils
         if: steps.check-keys.outputs.keys_available == 'true'
         run: npm run build --workspace=packages/shared-utils

--- a/packages/e2e/tests/free-mode/consensus-presets.spec.ts
+++ b/packages/e2e/tests/free-mode/consensus-presets.spec.ts
@@ -84,7 +84,7 @@ test.describe('Consensus Presets (Free Mode)', () => {
       // ELO should be disabled (requires 3+ models)
       const eloRadio = page.getByTestId('preset-elo');
       await expect(eloRadio).toBeDisabled();
-      await expect(page.getByText(/requires at least 3 models/i)).toBeVisible();
+      await expect(page.getByTestId('preset-min-models-warning')).toBeVisible();
     });
 
     // ==========================================


### PR DESCRIPTION
## Summary

Main has been failing since Feb 17 with two distinct issues:

- **Build shared-utils failure** (since Feb 19): Deploy and Eval Post-Merge workflows run `npm run build --workspace=packages/shared-utils` without first building the consensus packages that shared-utils re-exports from. Added consensus package build steps before shared-utils in both workflows.

- **E2E Free Mode failure** (since Feb 17, PR #285): `consensus-presets.spec.ts` uses a stale text selector (`getByText(/requires at least 3 models/i)`) that was removed when the ConsensusPresetSelector was updated. Updated to use `getByTestId('preset-min-models-warning')` matching the already-fixed mock-mode test.

## Test plan

- [ ] Deploy workflow builds shared-utils successfully
- [ ] Eval Post-Merge workflow builds shared-utils successfully  
- [ ] E2E Free Mode consensus-presets test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)