### PR TITLE
fix(ci): add apphosting:build for Firebase App Hosting consensus deps

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "apphosting:build": "cd ../.. && npm run build --workspace=packages/consensus-core && npm run build --workspace=packages/consensus-standard && npm run build --workspace=packages/consensus-elo && npm run build --workspace=packages/consensus-majority && npm run build --workspace=packages/consensus-council && npm run build --workspace=packages/shared-utils && cd packages/app && next build && node scripts/flatten-standalone.mjs",
     "build": "next build && node scripts/flatten-standalone.mjs",
     "check": "next lint && tsc --noEmit",
     "dev": "npm run dev:free",


### PR DESCRIPTION
## Summary

- Firebase App Hosting builds have been failing since commit `9688138` because it runs `npm run build` in `packages/app` without first building the consensus workspace packages that `shared-utils` depends on
- PR #306 fixed the GitHub Actions workflows but Firebase App Hosting uses its own build pipeline
- Adds an `apphosting:build` script to `packages/app/package.json` — Firebase [prefers this over `build`](https://firebase.google.com/docs/app-hosting/build) — which builds all consensus packages and shared-utils before running `next build`

## Test plan

- [ ] Firebase App Hosting rollout checks pass (both `ai-ensemble-48e5f` and `ensemble-ai-prod`)
- [ ] All CI checks pass
- [ ] Verified consensus + shared-utils + app build locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)