### PR TITLE
fix(ui): separate provider and model logos across app

### DIFF
--- a/packages/app/src/app/config/hooks/useConfigPage.ts
+++ b/packages/app/src/app/config/hooks/useConfigPage.ts
@@ -189,6 +189,16 @@ export function useConfigPage() {
                 showKey: apiKeys.xai?.visible ?? false,
             },
             {
+                provider: 'deepseek' as Provider,
+                label: 'DeepSeek API Key',
+                value: apiKeys.deepseek?.key ?? '',
+                placeholder: 'sk-...',
+                helperText: hydratedStatuses.deepseek === 'valid' ? 'API key configured' : hydratedStatuses.deepseek === 'validating' ? 'Validating...' : hydratedStatuses.deepseek === 'invalid' ? 'Invalid API key' : 'Enter your DeepSeek API key',
+                error: apiKeys.deepseek?.error,
+                validationStatus: hydratedStatuses.deepseek,
+                showKey: apiKeys.deepseek?.visible ?? false,
+            },
+            {
                 provider: 'perplexity' as Provider,
                 label: 'Perplexity API Key',
                 value: apiKeys.perplexity?.key ?? '',

--- a/packages/app/src/app/review/_components/ResponseCardSkeleton.test.tsx
+++ b/packages/app/src/app/review/_components/ResponseCardSkeleton.test.tsx
@@ -15,6 +15,8 @@ describe('ResponseCardSkeleton', () => {
     expect(screen.getByTestId('skeleton-1')).toBeInTheDocument();
     expect(screen.getByText('GPT-4')).toBeInTheDocument();
     expect(screen.getByText('OpenAI')).toBeInTheDocument();
+    expect(screen.getByTestId('provider-logo-openai')).toBeInTheDocument();
+    expect(screen.getByTestId('model-logo-openai')).toBeInTheDocument();
   });
 
   it('maps provider keys to display names', () => {
@@ -22,11 +24,13 @@ describe('ResponseCardSkeleton', () => {
       <ResponseCardSkeleton modelName="Claude" provider="anthropic" />
     );
     expect(screen.getByText('Anthropic')).toBeInTheDocument();
+    expect(screen.getByTestId('model-logo-anthropic')).toHaveAttribute('data-logo-key', 'claude');
 
     rerender(
       <ResponseCardSkeleton modelName="Gemini" provider="google" />
     );
     expect(screen.getByText('Google')).toBeInTheDocument();
+    expect(screen.getByTestId('model-logo-google')).toHaveAttribute('data-logo-key', 'gemini');
   });
 
   it('renders aria-busy for loading state', () => {

--- a/packages/app/src/app/review/_components/ResponseCardSkeleton.tsx
+++ b/packages/app/src/app/review/_components/ResponseCardSkeleton.tsx
@@ -4,6 +4,8 @@
  */
 
 import { Card, CardHeader, CardContent } from "@/components/atoms/Card";
+import { ProviderLogo } from "@/components/atoms/ProviderLogo";
+import { ModelLogo } from "@/components/atoms/ModelLogo";
 import { PROVIDER_NAMES, type Provider } from "@/components/molecules/ResponseCard";
 
 interface ResponseCardSkeletonProps {
@@ -27,11 +29,13 @@ export function ResponseCardSkeleton({
       <CardHeader className="pb-3">
         <div className="flex items-start justify-between gap-2">
           <div className="flex items-center gap-2">
-            <span className="rounded-full border px-2.5 py-0.5 text-xs font-semibold text-muted-foreground">
+            <span className="inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-semibold text-muted-foreground">
+              <ProviderLogo provider={provider} size="sm" />
               {PROVIDER_NAMES[provider]}
             </span>
-            <span className="text-base font-semibold text-muted-foreground">
-              {modelName}
+            <span className="inline-flex items-center gap-1.5 text-base font-semibold text-muted-foreground">
+              <ModelLogo provider={provider} modelName={modelName} size="sm" />
+              <span>{modelName}</span>
             </span>
           </div>
           <div className="h-5 w-16 animate-pulse rounded bg-muted" />

--- a/packages/component-library/src/components/atoms/ModelLogo/ModelLogo.stories.tsx
+++ b/packages/component-library/src/components/atoms/ModelLogo/ModelLogo.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ModelLogo } from './ModelLogo';
+
+const meta = {
+  title: 'Atoms/ModelLogo',
+  component: ModelLogo,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    provider: {
+      control: 'select',
+      options: ['openai', 'anthropic', 'google', 'xai', 'deepseek', 'perplexity'],
+    },
+    modelName: {
+      control: 'text',
+    },
+    modelId: {
+      control: 'text',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'default', 'lg', 'xl'],
+    },
+  },
+} satisfies Meta<typeof ModelLogo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const OpenAI: Story = {
+  args: { provider: 'openai', modelName: 'GPT-4o', size: 'lg' },
+};
+
+export const Claude: Story = {
+  args: { provider: 'anthropic', modelName: 'Claude Sonnet 4.6', size: 'lg' },
+};
+
+export const Gemini: Story = {
+  args: { provider: 'google', modelName: 'Gemini 2.5 Pro', size: 'lg' },
+};
+
+export const Grok: Story = {
+  args: { provider: 'xai', modelName: 'Grok 4', size: 'lg' },
+};
+
+export const ProviderFallback: Story = {
+  args: { provider: 'anthropic', modelName: 'Experimental Sonnet', size: 'lg' },
+};
+
+export const AllModelFamilies: Story = {
+  args: {
+    provider: 'openai',
+    modelName: 'GPT-4o',
+    size: 'xl',
+  },
+  render: () => (
+    <div className="flex items-center gap-6">
+      <div className="flex flex-col items-center gap-2">
+        <ModelLogo provider="openai" modelName="GPT-4o" size="xl" />
+        <span className="text-xs text-muted-foreground">GPT</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <ModelLogo provider="anthropic" modelName="Claude Sonnet 4.6" size="xl" />
+        <span className="text-xs text-muted-foreground">Claude</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <ModelLogo provider="google" modelName="Gemini 2.5 Pro" size="xl" />
+        <span className="text-xs text-muted-foreground">Gemini</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <ModelLogo provider="xai" modelName="Grok 4" size="xl" />
+        <span className="text-xs text-muted-foreground">Grok</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <ModelLogo provider="deepseek" modelName="DeepSeek Reasoner" size="xl" />
+        <span className="text-xs text-muted-foreground">DeepSeek</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <ModelLogo provider="perplexity" modelName="Sonar Pro" size="xl" />
+        <span className="text-xs text-muted-foreground">Perplexity</span>
+      </div>
+    </div>
+  ),
+};

--- a/packages/component-library/src/components/atoms/ModelLogo/ModelLogo.test.tsx
+++ b/packages/component-library/src/components/atoms/ModelLogo/ModelLogo.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ModelLogo, resolveModelLogoKey } from './ModelLogo';
+
+const PROVIDERS = ['openai', 'anthropic', 'google', 'xai', 'deepseek', 'perplexity'] as const;
+
+describe('ModelLogo', () => {
+  describe('rendering', () => {
+    it.each(PROVIDERS)('renders %s model logo', (provider) => {
+      render(<ModelLogo provider={provider} />);
+      const logo = screen.getByTestId(`model-logo-${provider}`);
+      expect(logo).toBeInTheDocument();
+      expect(logo.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('uses Claude logo for Anthropic Claude models', () => {
+      render(<ModelLogo provider="anthropic" modelName="Claude 3.7 Sonnet" />);
+      expect(screen.getByTestId('model-logo-anthropic')).toHaveAttribute('data-logo-key', 'claude');
+    });
+
+    it('uses Gemini logo for Google Gemini models', () => {
+      render(<ModelLogo provider="google" modelName="Gemini 2.5 Flash" />);
+      expect(screen.getByTestId('model-logo-google')).toHaveAttribute('data-logo-key', 'gemini');
+    });
+
+    it('uses Grok logo for xAI Grok models', () => {
+      render(<ModelLogo provider="xai" modelName="Grok 4" />);
+      expect(screen.getByTestId('model-logo-xai')).toHaveAttribute('data-logo-key', 'grok');
+    });
+  });
+
+  describe('fallback behavior', () => {
+    it('falls back to Anthropic provider logo when model family is unknown', () => {
+      render(<ModelLogo provider="anthropic" modelName="Sonnet Experimental" />);
+      expect(screen.getByTestId('model-logo-anthropic')).toHaveAttribute('data-logo-key', 'anthropic');
+    });
+
+    it('falls back to DeepMind provider logo when Google model family is unknown', () => {
+      render(<ModelLogo provider="google" modelName="PaLM Legacy" />);
+      expect(screen.getByTestId('model-logo-google')).toHaveAttribute('data-logo-key', 'deepmind');
+    });
+
+    it('falls back to XAI provider logo when xAI model family is unknown', () => {
+      render(<ModelLogo provider="xai" modelName="Reasoning Beta" />);
+      expect(screen.getByTestId('model-logo-xai')).toHaveAttribute('data-logo-key', 'xai');
+    });
+  });
+
+  describe('resolver', () => {
+    it('resolves from model id when model name is unavailable', () => {
+      expect(resolveModelLogoKey('anthropic', undefined, 'claude-opus-4')).toBe('claude');
+      expect(resolveModelLogoKey('google', undefined, 'gemini-2.5-pro')).toBe('gemini');
+      expect(resolveModelLogoKey('xai', undefined, 'grok-4')).toBe('grok');
+    });
+  });
+
+  describe('sizes and accessibility', () => {
+    it('renders default size when no size provided', () => {
+      render(<ModelLogo provider="openai" />);
+      expect(screen.getByTestId('model-logo-openai')).toHaveAttribute('data-size', 'default');
+    });
+
+    it('renders explicit size when provided', () => {
+      render(<ModelLogo provider="openai" size="lg" />);
+      expect(screen.getByTestId('model-logo-openai')).toHaveAttribute('data-size', 'lg');
+    });
+
+    it.each(PROVIDERS)('has accessible role and label for %s', (provider) => {
+      render(<ModelLogo provider={provider} />);
+      const logo = screen.getByTestId(`model-logo-${provider}`);
+      expect(logo).toHaveAttribute('role', 'img');
+      expect(logo).toHaveAttribute('aria-label', `${provider} model logo`);
+    });
+  });
+});

--- a/packages/component-library/src/components/atoms/ModelLogo/ModelLogo.tsx
+++ b/packages/component-library/src/components/atoms/ModelLogo/ModelLogo.tsx
@@ -1,0 +1,163 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+import OpenAIMono from '@lobehub/icons/es/OpenAI/components/Mono';
+import AnthropicMono from '@lobehub/icons/es/Anthropic/components/Mono';
+import DeepMindMono from '@lobehub/icons/es/DeepMind/components/Mono';
+import XAIMono from '@lobehub/icons/es/XAI/components/Mono';
+import DeepSeekMono from '@lobehub/icons/es/DeepSeek/components/Mono';
+import PerplexityMono from '@lobehub/icons/es/Perplexity/components/Mono';
+import ClaudeMono from '@lobehub/icons/es/Claude/components/Mono';
+import GeminiMono from '@lobehub/icons/es/Gemini/components/Mono';
+import GrokMono from '@lobehub/icons/es/Grok/components/Mono';
+import type { ProviderLogoProvider } from '../ProviderLogo';
+
+const SIZE_MAP = {
+  sm: 20,
+  default: 24,
+  lg: 32,
+  xl: 40,
+} as const;
+
+const modelLogoVariants = cva('inline-flex shrink-0 items-center justify-center', {
+  variants: {
+    size: {
+      sm: 'h-5 w-5',
+      default: 'h-6 w-6',
+      lg: 'h-8 w-8',
+      xl: 'h-10 w-10',
+    },
+  },
+  defaultVariants: {
+    size: 'default',
+  },
+});
+
+export type ModelLogoProvider = ProviderLogoProvider;
+
+type ModelLogoKey =
+  | 'openai'
+  | 'anthropic'
+  | 'deepmind'
+  | 'xai'
+  | 'deepseek'
+  | 'perplexity'
+  | 'claude'
+  | 'gemini'
+  | 'grok';
+
+export interface ModelLogoProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'children'>,
+    VariantProps<typeof modelLogoVariants> {
+  /** The provider that owns the model */
+  provider: ModelLogoProvider;
+  /** Optional model display name (e.g., "Claude Sonnet 4.6") */
+  modelName?: string;
+  /** Optional model identifier (e.g., "claude-sonnet-4-6") */
+  modelId?: string;
+}
+
+const MODEL_ICON_KEYS: Record<ModelLogoProvider, ModelLogoKey> = {
+  openai: 'openai',
+  anthropic: 'claude',
+  google: 'gemini',
+  xai: 'grok',
+  deepseek: 'deepseek',
+  perplexity: 'perplexity',
+};
+
+const PROVIDER_FALLBACK_KEYS: Record<ModelLogoProvider, ModelLogoKey> = {
+  openai: 'openai',
+  anthropic: 'anthropic',
+  google: 'deepmind',
+  xai: 'xai',
+  deepseek: 'deepseek',
+  perplexity: 'perplexity',
+};
+
+const MODEL_NAME_MATCHERS: Partial<Record<ModelLogoProvider, RegExp>> = {
+  anthropic: /\bclaude\b/i,
+  google: /\bgemini\b/i,
+  xai: /\bgrok\b/i,
+};
+
+type IconComponent = React.ComponentType<{ size?: number }>;
+
+const LOGO_COMPONENTS: Record<ModelLogoKey, IconComponent> = {
+  openai: OpenAIMono,
+  anthropic: AnthropicMono,
+  deepmind: DeepMindMono,
+  xai: XAIMono,
+  deepseek: DeepSeekMono,
+  perplexity: PerplexityMono,
+  claude: ClaudeMono,
+  gemini: GeminiMono,
+  grok: GrokMono,
+};
+
+function resolveModelLogoKey(
+  provider: ModelLogoProvider,
+  modelName?: string,
+  modelId?: string,
+): ModelLogoKey {
+  const matcher = MODEL_NAME_MATCHERS[provider];
+  if (!matcher) {
+    return MODEL_ICON_KEYS[provider];
+  }
+
+  const signal = `${modelName ?? ''} ${modelId ?? ''}`.trim();
+  if (signal.length > 0 && !matcher.test(signal)) {
+    return PROVIDER_FALLBACK_KEYS[provider];
+  }
+
+  return MODEL_ICON_KEYS[provider];
+}
+
+/**
+ * Wrapper that strips `<title>` elements from lobehub icon SVGs
+ * to prevent duplicate accessible text when used beside model labels.
+ */
+const TitleStripper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const containerRef = React.useRef<HTMLSpanElement>(null);
+
+  React.useEffect(() => {
+    const title = containerRef.current?.querySelector('svg > title');
+    if (title) title.remove();
+  }, []);
+
+  return <span ref={containerRef}>{children}</span>;
+};
+
+/**
+ * ModelLogo atom for displaying model-brand logos while preserving
+ * provider fallbacks when the model family cannot be inferred.
+ */
+const ModelLogo = React.forwardRef<HTMLSpanElement, ModelLogoProps>(
+  ({ className, size, provider, modelName, modelId, ...props }, ref) => {
+    const logoKey = resolveModelLogoKey(provider, modelName, modelId);
+    const IconComponent = LOGO_COMPONENTS[logoKey];
+    const pxSize = SIZE_MAP[size || 'default'];
+
+    return (
+      <span
+        ref={ref}
+        className={cn(modelLogoVariants({ size }), className)}
+        role="img"
+        aria-label={`${provider} model logo`}
+        data-testid={`model-logo-${provider}`}
+        data-provider={provider}
+        data-size={size || 'default'}
+        data-logo-key={logoKey}
+        {...props}
+      >
+        <TitleStripper>
+          <IconComponent size={pxSize} />
+        </TitleStripper>
+      </span>
+    );
+  },
+);
+
+ModelLogo.displayName = 'ModelLogo';
+
+export { ModelLogo, modelLogoVariants, resolveModelLogoKey };

--- a/packages/component-library/src/components/atoms/ModelLogo/index.ts
+++ b/packages/component-library/src/components/atoms/ModelLogo/index.ts
@@ -1,0 +1,7 @@
+export {
+  ModelLogo,
+  modelLogoVariants,
+  resolveModelLogoKey,
+  type ModelLogoProps,
+  type ModelLogoProvider,
+} from './ModelLogo';

--- a/packages/component-library/src/components/molecules/ModelCard/ModelCard.test.tsx
+++ b/packages/component-library/src/components/molecules/ModelCard/ModelCard.test.tsx
@@ -17,9 +17,9 @@ describe('ModelCard', () => {
       expect(card).toBeInTheDocument();
     });
 
-    it('renders provider logo', () => {
+    it('renders model logo', () => {
       render(<ModelCard provider="openai" modelName="GPT-4" selected={false} isSummarizer={false} />);
-      expect(screen.getByTestId('provider-logo-openai')).toBeInTheDocument();
+      expect(screen.getByTestId('model-logo-openai')).toBeInTheDocument();
     });
 
     it('renders card content', () => {
@@ -98,24 +98,24 @@ describe('ModelCard', () => {
   });
 
   describe('provider-specific behavior', () => {
-    it('renders OpenAI provider logo correctly', () => {
+    it('renders OpenAI model logo correctly', () => {
       render(<ModelCard provider="openai" modelName="GPT-4" selected={false} isSummarizer={false} />);
-      expect(screen.getByTestId('provider-logo-openai')).toBeInTheDocument();
+      expect(screen.getByTestId('model-logo-openai')).toHaveAttribute('data-logo-key', 'openai');
     });
 
-    it('renders Anthropic provider logo correctly', () => {
+    it('renders Claude model logo for Anthropic models', () => {
       render(<ModelCard provider="anthropic" modelName="Claude 3.5 Sonnet" selected={false} isSummarizer={false} />);
-      expect(screen.getByTestId('provider-logo-anthropic')).toBeInTheDocument();
+      expect(screen.getByTestId('model-logo-anthropic')).toHaveAttribute('data-logo-key', 'claude');
     });
 
-    it('renders Google provider logo correctly', () => {
+    it('renders Gemini model logo for Google models', () => {
       render(<ModelCard provider="google" modelName="Gemini Pro" selected={false} isSummarizer={false} />);
-      expect(screen.getByTestId('provider-logo-google')).toBeInTheDocument();
+      expect(screen.getByTestId('model-logo-google')).toHaveAttribute('data-logo-key', 'gemini');
     });
 
-    it('renders XAI provider logo correctly', () => {
+    it('renders Grok model logo for xAI models', () => {
       render(<ModelCard provider="xai" modelName="Grok" selected={false} isSummarizer={false} />);
-      expect(screen.getByTestId('provider-logo-xai')).toBeInTheDocument();
+      expect(screen.getByTestId('model-logo-xai')).toHaveAttribute('data-logo-key', 'grok');
     });
 
     it('applies correct provider data attribute', () => {

--- a/packages/component-library/src/components/molecules/ModelCard/ModelCard.tsx
+++ b/packages/component-library/src/components/molecules/ModelCard/ModelCard.tsx
@@ -3,10 +3,10 @@ import { useTranslation } from 'react-i18next';
 import type { ModelModality } from '@ensemble-ai/shared-utils/providers';
 import { Card, CardContent } from '../../atoms/Card';
 import { Badge } from '../../atoms/Badge';
-import { ProviderLogo, type ProviderLogoProvider } from '../../atoms/ProviderLogo';
+import { ModelLogo, type ModelLogoProvider } from '../../atoms/ModelLogo';
 import { cn } from '@/lib/utils';
 
-export type Provider = ProviderLogoProvider;
+export type Provider = ModelLogoProvider;
 export type { ModelModality };
 
 export interface ModelCardProps {
@@ -34,7 +34,7 @@ export interface ModelCardProps {
  * ModelCard molecule for selecting AI models in an ensemble.
  *
  * Combines Card and Badge atoms to create a clean, centered selectable model card
- * matching the wireframe design with provider icons and selection states.
+ * matching the wireframe design with model-brand logos and selection states.
  *
  * @example
  * ```tsx
@@ -116,7 +116,12 @@ export const ModelCard = React.forwardRef<HTMLDivElement, ModelCardProps>(
       >
         <CardContent className="p-4 text-center">
           <div className="mb-2 flex justify-center">
-            <ProviderLogo provider={provider} size="lg" />
+            <ModelLogo
+              provider={provider}
+              modelName={modelName}
+              modelId={modelId}
+              size="lg"
+            />
           </div>
           <div className="font-medium text-sm">{modelName}</div>
           {modalities.length > 0 && (

--- a/packages/component-library/src/components/molecules/ResponseCard/ResponseCard.test.tsx
+++ b/packages/component-library/src/components/molecules/ResponseCard/ResponseCard.test.tsx
@@ -326,6 +326,7 @@ describe('ResponseCard', () => {
         />
       );
       expect(screen.getByText('Anthropic')).toBeInTheDocument();
+      expect(screen.getByTestId('model-logo-anthropic')).toHaveAttribute('data-logo-key', 'claude');
     });
 
     it('renders Google provider correctly', () => {
@@ -339,6 +340,7 @@ describe('ResponseCard', () => {
         />
       );
       expect(screen.getByText('Google')).toBeInTheDocument();
+      expect(screen.getByTestId('model-logo-google')).toHaveAttribute('data-logo-key', 'gemini');
     });
 
     it('renders XAI provider correctly', () => {
@@ -352,6 +354,7 @@ describe('ResponseCard', () => {
         />
       );
       expect(screen.getByText('XAI')).toBeInTheDocument();
+      expect(screen.getByTestId('model-logo-xai')).toHaveAttribute('data-logo-key', 'grok');
     });
   });
 

--- a/packages/component-library/src/components/molecules/ResponseCard/ResponseCard.tsx
+++ b/packages/component-library/src/components/molecules/ResponseCard/ResponseCard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Card, CardHeader, CardContent } from '../../atoms/Card';
 import { Badge } from '../../atoms/Badge';
 import { ProviderLogo, type ProviderLogoProvider } from '../../atoms/ProviderLogo';
+import { ModelLogo } from '../../atoms/ModelLogo';
 import { LoadingSpinner } from '../../atoms/LoadingSpinner';
 import { InlineAlert } from '../../atoms/InlineAlert';
 import { Rating } from '../../atoms/Rating';
@@ -142,7 +143,14 @@ export const ResponseCard = React.forwardRef<HTMLDivElement, ResponseCardProps>(
                       {PROVIDER_NAMES[provider]}
                     </Badge>
                   )}
-                  {modelName && <span className="font-semibold text-base">{modelName}</span>}
+                  {modelName && (
+                    <span className="inline-flex items-center gap-1.5 font-semibold text-base">
+                      {provider && (
+                        <ModelLogo provider={provider} modelName={modelName} size="sm" />
+                      )}
+                      <span>{modelName}</span>
+                    </span>
+                  )}
                 </>
               )}
             </div>

--- a/packages/component-library/src/components/organisms/ModelSelectionList/ModelSelectionList.test.tsx
+++ b/packages/component-library/src/components/organisms/ModelSelectionList/ModelSelectionList.test.tsx
@@ -47,6 +47,10 @@ describe('ModelSelectionList', () => {
       expect(screen.getByText('Anthropic')).toBeInTheDocument();
       expect(screen.getByText('Google')).toBeInTheDocument();
       expect(screen.getByText('XAI')).toBeInTheDocument();
+      expect(screen.getByTestId('provider-logo-openai')).toBeInTheDocument();
+      expect(screen.getByTestId('provider-logo-anthropic')).toBeInTheDocument();
+      expect(screen.getByTestId('provider-logo-google')).toBeInTheDocument();
+      expect(screen.getByTestId('provider-logo-xai')).toBeInTheDocument();
     });
 
     it('groups models by provider', () => {
@@ -499,7 +503,7 @@ describe('ModelSelectionList', () => {
         />
       );
 
-      const gpt4Card = container.querySelector('[data-provider="openai"]');
+      const gpt4Card = container.querySelector('[data-testid="model-card-gpt-4"]');
       expect(gpt4Card).toHaveAttribute('data-selected', 'true');
       expect(gpt4Card).toHaveAttribute('data-summarizer', 'true');
     });

--- a/packages/component-library/src/components/organisms/ModelSelectionList/ModelSelectionList.tsx
+++ b/packages/component-library/src/components/organisms/ModelSelectionList/ModelSelectionList.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ModelCard, type ModelModality, type Provider } from '../../molecules/ModelCard';
 import { Heading } from '../../atoms/Heading';
+import { ProviderLogo } from '../../atoms/ProviderLogo';
 
 export interface Model {
   id: string;
@@ -114,7 +115,12 @@ export const ModelSelectionList = React.forwardRef<HTMLDivElement, ModelSelectio
             <div key={provider} data-testid="provider-section" className="mb-8">
               {/* Provider Header */}
               <div className="flex items-center justify-between mb-4">
-                <Heading level={4} size="lg" className="text-foreground">{t(`providers.${provider}`)}</Heading>
+                <div className="flex items-center gap-2">
+                  <ProviderLogo provider={provider} size="sm" />
+                  <Heading level={4} size="lg" className="text-foreground">
+                    {t(`providers.${provider}`)}
+                  </Heading>
+                </div>
                 {providerStatus?.[provider] && (
                   <div className="flex items-center gap-2">
                     {providerStatus[provider] === 'Ready' ? (

--- a/packages/component-library/src/index.ts
+++ b/packages/component-library/src/index.ts
@@ -15,6 +15,13 @@ export { Input } from './components/atoms/Input';
 export { Badge, badgeVariants, type BadgeProps } from './components/atoms/Badge';
 export { Icon, iconVariants, type IconProps } from './components/atoms/Icon';
 export { ProviderLogo, providerLogoVariants, type ProviderLogoProps, type ProviderLogoProvider } from './components/atoms/ProviderLogo';
+export {
+  ModelLogo,
+  modelLogoVariants,
+  resolveModelLogoKey,
+  type ModelLogoProps,
+  type ModelLogoProvider,
+} from './components/atoms/ModelLogo';
 export { LoadingSpinner, type LoadingSpinnerProps } from './components/atoms/LoadingSpinner';
 export { Tag, tagVariants, type TagProps } from './components/atoms/Tag';
 export { InlineAlert, type InlineAlertProps } from './components/atoms/InlineAlert';


### PR DESCRIPTION
## Summary
- add a dedicated `ModelLogo` atom and export it from the component library
- apply model logos on model-level cards/skeletons and provider logos on provider section headers
- audit and update tests/stories for logo behavior
- restore DeepSeek API key entry in config via `useConfigPage`

## Validation
- `npm run lint --workspace=packages/component-library`
- `npm exec -w packages/component-library vitest run src/components/atoms/ModelLogo/ModelLogo.test.tsx src/components/molecules/ModelCard/ModelCard.test.tsx src/components/organisms/ModelSelectionList/ModelSelectionList.test.tsx src/components/molecules/ResponseCard/ResponseCard.test.tsx`
- `npm exec -w packages/app vitest run src/app/review/_components/ResponseCardSkeleton.test.tsx`
- `npm run lint --workspace=packages/app`
- `npm run typecheck --workspace=packages/app`

## Notes
- this change is scoped to provider vs model logo correctness and config key visibility
