### PR TITLE
fix(sentry): capture handled errors and prevent consensus browser crashes

### DIFF
--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -15,5 +15,6 @@
 
 # Sentry error monitoring (optional — omit to disable)
 # NEXT_PUBLIC_SENTRY_DSN="https://examplePublicKey@o0.ingest.sentry.io/0"
-# Set to true if you want handled tRPC application errors captured as exceptions.
+# Set to "false" to suppress handled tRPC application errors.
+# Default behavior captures handled + unhandled tRPC errors in Sentry.
 # SENTRY_CAPTURE_HANDLED_TRPC_ERRORS="false"

--- a/packages/app/src/app/api/trpc/[trpc]/route.ts
+++ b/packages/app/src/app/api/trpc/[trpc]/route.ts
@@ -17,7 +17,7 @@ const createContext = async (req: NextRequest) => {
 };
 
 const captureHandledTrpcErrors =
-  process.env.SENTRY_CAPTURE_HANDLED_TRPC_ERRORS === "true";
+  process.env.SENTRY_CAPTURE_HANDLED_TRPC_ERRORS !== "false";
 
 const handler = (req: NextRequest) =>
   fetchRequestHandler({

--- a/packages/app/src/app/config/hooks/useConfigPage.ts
+++ b/packages/app/src/app/config/hooks/useConfigPage.ts
@@ -119,7 +119,7 @@ export function useConfigPage() {
 
     const handleKeyChange = (provider: Provider, value: string) => {
         void setApiKey(provider, value).catch((error: unknown) => {
-            console.error(
+            logger.error(
                 `Failed to store ${provider} API key`,
                 toError(error, `Unable to store ${provider} API key`),
             );

--- a/packages/app/src/app/ensemble/hooks/useApiKeyModal.ts
+++ b/packages/app/src/app/ensemble/hooks/useApiKeyModal.ts
@@ -3,6 +3,7 @@ import type { Provider, ValidationStatus } from '@/components/molecules/ApiKeyIn
 import type { StoreState } from '~/store';
 import type { OperatingMode } from '~/store/slices/modeSlice';
 import { toError } from '~/lib/errors';
+import { logger } from '~/lib/logger';
 
 interface UseApiKeyModalOptions {
   safeApiKeys: StoreState['apiKeys'];
@@ -66,7 +67,7 @@ export function useApiKeyModal({
 
   const handleKeyChange = (provider: Provider, value: string) => {
     void setApiKey(provider, value).catch((error: unknown) => {
-      console.error(
+      logger.error(
         `Failed to store ${provider} API key`,
         toError(error, `Unable to store ${provider} API key`),
       );

--- a/packages/app/src/app/prompt/page.tsx
+++ b/packages/app/src/app/prompt/page.tsx
@@ -25,6 +25,7 @@ import {
 } from '@ensemble-ai/shared-utils/providers';
 import { FALLBACK_MODELS } from '~/lib/models';
 import { toError } from '~/lib/errors';
+import { logger } from '~/lib/logger';
 
 export default function PromptPage() {
   const { t } = useTranslation();
@@ -122,12 +123,21 @@ export default function PromptPage() {
             completeResponse(selection.id, responseTime, tokenCount);
           },
           (error: Error) => {
+            logger.error(
+              `[PromptPage] streamResponse error for ${selection.provider}/${selection.model}`,
+              error,
+            );
             setError(selection.id, error.message);
           },
         )
-        .catch((error: unknown) =>
-          setError(selection.id, toError(error).message),
-        );
+        .catch((error: unknown) => {
+          const normalizedError = toError(error);
+          logger.error(
+            `[PromptPage] streamResponse exception for ${selection.provider}/${selection.model}`,
+            normalizedError,
+          );
+          setError(selection.id, normalizedError.message);
+        });
     });
 
     completeStep('prompt');

--- a/packages/app/src/app/review/hooks/useResponseEmbeddings.ts
+++ b/packages/app/src/app/review/hooks/useResponseEmbeddings.ts
@@ -3,6 +3,7 @@ import type { ProviderType } from '~/store/slices/ensembleSlice';
 import type { OperatingMode } from '~/store/slices/modeSlice';
 import { generateEmbeddingsForResponses } from '~/lib/embeddings';
 import { toError } from '~/lib/errors';
+import { logger } from '~/lib/logger';
 import type { ModelResponse } from '~/store';
 type Embedding = { modelId: string; embedding: number[] };
 
@@ -72,7 +73,7 @@ export function useResponseEmbeddings({
         provider: embeddingsProvider,
         mode: mode === 'pro' ? 'pro' : 'free',
         onError: (modelId, error: Error) => {
-          console.error(
+          logger.error(
             `Failed to generate embeddings for ${modelId} via ${embeddingsProvider}`,
             error,
           );
@@ -89,7 +90,7 @@ export function useResponseEmbeddings({
         calculateAgreementState();
       }
     })().catch((error: unknown) => {
-      console.error(
+      logger.error(
         'Failed to process embeddings',
         toError(error, 'Unable to process embeddings'),
       );

--- a/packages/app/src/app/review/hooks/useStreamingResponses.ts
+++ b/packages/app/src/app/review/hooks/useStreamingResponses.ts
@@ -8,6 +8,7 @@ import {
 import { initializeProviders } from "~/providers";
 import { FALLBACK_MODELS } from "~/lib/models";
 import { formatModelLabelFromId } from "~/lib/providerModels";
+import { logger } from "~/lib/logger";
 
 interface UseStreamingResponsesProps {
   hasHydrated: boolean;
@@ -111,7 +112,7 @@ export function useStreamingResponses({
           completeResponse(model.id, responseTime, tokenCount);
         },
         (error) => {
-          console.error(`[useStreamingResponses] Error for ${modelId}:`, error);
+          logger.error(`[useStreamingResponses] Error for ${modelId}:`, error);
           if (flushIntervals.current[modelId]) {
             clearInterval(flushIntervals.current[modelId]);
             delete flushIntervals.current[modelId];
@@ -120,11 +121,17 @@ export function useStreamingResponses({
         },
       );
     } catch (err) {
+      const normalizedError =
+        err instanceof Error ? err : new Error(String(err));
+      logger.error(
+        `[useStreamingResponses] Exception for ${modelId}:`,
+        normalizedError,
+      );
       if (flushIntervals.current[modelId]) {
         clearInterval(flushIntervals.current[modelId]);
         delete flushIntervals.current[modelId];
       }
-      setError(model.id, err instanceof Error ? err.message : String(err));
+      setError(model.id, normalizedError.message);
     }
   };
 

--- a/packages/app/src/lib/embeddings.ts
+++ b/packages/app/src/lib/embeddings.ts
@@ -6,6 +6,7 @@ import {
 import type { ModelResponse } from '~/store';
 import type { ProviderType } from '~/store/slices/ensembleSlice';
 import { toError } from '~/lib/errors';
+import { logger } from '~/lib/logger';
 
 export type EmbeddingVector = {
   modelId: string;
@@ -76,7 +77,7 @@ export async function generateEmbeddingsForResponses({
   const handleError =
     onError ??
     ((modelId: string, error: Error) => {
-      console.error(
+      logger.error(
         `Failed to generate embeddings for ${modelId} via ${provider} (${resolvedMode})`,
         error,
       );

--- a/packages/app/src/lib/i18n.ts
+++ b/packages/app/src/lib/i18n.ts
@@ -9,6 +9,7 @@ import frAppTranslations from '../../public/locales/fr/common.json';
 import enComponentTranslations from '@/lib/i18n/locales/en.json';
 import frComponentTranslations from '@/lib/i18n/locales/fr.json';
 import { toError } from './errors';
+import { logger } from './logger';
 
 /**
  * i18next configuration for Ensemble AI
@@ -44,7 +45,7 @@ i18n
     },
   })
   .catch((error: unknown) => {
-    console.error(
+    logger.error(
       'i18n initialization failed:',
       toError(error, 'i18n initialization failed'),
     );

--- a/packages/app/src/lib/validation.ts
+++ b/packages/app/src/lib/validation.ts
@@ -7,6 +7,7 @@ import type { ValidationStatus } from '@/components/molecules/ApiKeyInput';
 import { ProviderRegistry } from '@ensemble-ai/shared-utils/providers';
 import { initializeProviders } from '~/providers';
 import { toError } from '~/lib/errors';
+import { logger } from '~/lib/logger';
 
 export interface ValidateApiKeyOptions {
   provider: Provider;
@@ -87,7 +88,7 @@ export async function validateApiKey({
       error,
       `Error validating ${provider} API key`,
     );
-    console.error(`Error validating ${provider} API key:`, normalizedError);
+    logger.error(`Error validating ${provider} API key:`, normalizedError);
 
     // Try to extract a user-friendly message
     let userMessage = normalizedError.message;

--- a/packages/app/src/store/middleware/persistenceMiddleware.ts
+++ b/packages/app/src/store/middleware/persistenceMiddleware.ts
@@ -1,5 +1,6 @@
 import type { StateCreator, StoreMutatorIdentifier } from 'zustand';
 import { toError } from '~/lib/errors';
+import { logger } from '~/lib/logger';
 
 /**
  * Persistence middleware for Zustand store
@@ -53,7 +54,7 @@ export const persist = <
         };
       }
     } catch (error: unknown) {
-      console.error(
+      logger.error(
         'Failed to parse stored state:',
         toError(error, 'Invalid persisted state'),
       );
@@ -71,7 +72,7 @@ export const persist = <
           : state;
         storage.setItem(name, JSON.stringify(stateToPersist));
       } catch (error: unknown) {
-        console.error(
+        logger.error(
           'Failed to persist state:',
           toError(error, 'Unable to persist state'),
         );

--- a/packages/app/src/store/slices/apiKeySlice.ts
+++ b/packages/app/src/store/slices/apiKeySlice.ts
@@ -10,6 +10,7 @@ import { decrypt, encrypt } from '@ensemble-ai/shared-utils/security';
 import type { ValidationStatus } from '@/components/molecules/ApiKeyInput';
 import type { ProviderType } from './ensembleSlice';
 import { toError } from '~/lib/errors';
+import { logger } from '~/lib/logger';
 
 export interface ApiKeyData {
   encrypted: string | null;
@@ -98,7 +99,7 @@ export const createApiKeySlice: StateCreator<ApiKeySlice> = (set, get) => ({
             error,
             `Failed to decrypt ${provider} API key`,
           );
-          console.error(`Failed to decrypt ${provider} API key`, normalizedError);
+          logger.error(`Failed to decrypt ${provider} API key`, normalizedError);
           set((state) => {
             const currentEntry = state.apiKeys[provider];
             return {
@@ -154,7 +155,7 @@ export const createApiKeySlice: StateCreator<ApiKeySlice> = (set, get) => ({
         error,
         `Failed to encrypt ${provider} API key`,
       );
-      console.error(`Failed to encrypt ${provider} API key`, normalizedError);
+      logger.error(`Failed to encrypt ${provider} API key`, normalizedError);
       throw normalizedError;
     }
   },

--- a/packages/consensus-standard/src/StandardConsensus.ts
+++ b/packages/consensus-standard/src/StandardConsensus.ts
@@ -1,6 +1,15 @@
 
 import type { AIProvider, ConsensusModelResponse, ConsensusStrategy, RankingResult } from '@ensemble-ai/consensus-core';
 
+function writeDebug(message: string): void {
+    const stderr = (globalThis as {
+        process?: { stderr?: { write?: (chunk: string) => void } };
+    }).process?.stderr;
+    if (typeof stderr?.write === 'function') {
+        stderr.write(message);
+    }
+}
+
 export class StandardConsensus implements ConsensusStrategy {
     constructor(
         private summarizerProvider: AIProvider,
@@ -25,7 +34,7 @@ export class StandardConsensus implements ConsensusStrategy {
     async generateConsensus(responses: ConsensusModelResponse[], topN: number, originalPrompt: string): Promise<string> {
         void topN; // Unused
         const sumStart = Date.now();
-        process.stderr.write(`    [standard] generateConsensus start: ${responses.length} responses\n`);
+        writeDebug(`    [standard] generateConsensus start: ${responses.length} responses\n`);
 
         const responsesText = responses.map(r => `Model: ${r.modelName}\nResponse:\n${r.content}`).join('\n\n---\n\n');
 
@@ -48,11 +57,11 @@ If the question asks for a constrained format (single letter, number, JSON, etc.
             this.summarizerProvider.streamResponse(prompt, this.summarizerModelId,
                 () => { void 0; },
                 (finalText: string) => {
-                    process.stderr.write(`    [standard] generateConsensus done in ${((Date.now() - sumStart) / 1000).toFixed(1)}s\n`);
+                    writeDebug(`    [standard] generateConsensus done in ${((Date.now() - sumStart) / 1000).toFixed(1)}s\n`);
                     resolve(finalText);
                 },
                 (err: Error) => {
-                    process.stderr.write(`    [standard] generateConsensus error in ${((Date.now() - sumStart) / 1000).toFixed(1)}s: ${err.message}\n`);
+                    writeDebug(`    [standard] generateConsensus error in ${((Date.now() - sumStart) / 1000).toFixed(1)}s: ${err.message}\n`);
                     resolve('Failed to generate summary.');
                 }
             );


### PR DESCRIPTION
## Summary
- capture handled runtime errors via Sentry-backed `logger.error` across app runtime paths (review hooks, prompt flow, i18n, API key storage/validation, persistence middleware)
- default tRPC handled error capture to enabled (`SENTRY_CAPTURE_HANDLED_TRPC_ERRORS` now opt-out via `false`)
- fix client-side consensus crashes by replacing direct `process.stderr.write(...)` calls with browser-safe debug logging guards in consensus packages
- treat consensus strategy failure sentinel outputs as errors in `useConsensusGeneration` so they surface in Sentry and UI state
- add startup script error queue in `layout.tsx` so pre-hydration script failures are captured after hydration

## Why
- frontend consensus failures were being caught and only printed to console, so no Sentry issue was created
- consensus packages emitted Node-only debug writes in browser code paths, triggering `Cannot read properties of undefined (reading 'write')`
- multiple handled app errors were never captured, which under-reported production failures

## Validation
- `npm run lint --workspace=packages/app`
- `npm run typecheck --workspace=packages/app`
- `npm run typecheck --workspace=packages/consensus-standard`
- `npm run typecheck --workspace=packages/consensus-majority`
- `npm run typecheck --workspace=packages/consensus-elo`
- `npm run typecheck --workspace=packages/consensus-council`
- `npm run test --workspace=packages/consensus-standard`
- `npm run test --workspace=packages/consensus-majority`
- `npm run test --workspace=packages/consensus-elo`
- `npm run test --workspace=packages/consensus-council`
- `npm exec -w packages/app vitest run src/store/__tests__/apiKeySlice.test.ts`
