### PR TITLE
fix(security): harden free-mode key handling and complete API key audit

### DIFF
--- a/docs/security-audit-issue-56.md
+++ b/docs/security-audit-issue-56.md
@@ -1,0 +1,51 @@
+# Security Audit Report: API Key Handling (Issue #56)
+
+**Date**: 2026-02-23  
+**Scope**: Free mode client key handling, Pro mode server-side key posture, and tRPC authorization setup.
+
+## Summary
+
+This audit reviewed API-key storage, request construction, error/logging behavior, and server route authorization posture.
+
+## Findings and Status
+
+- [x] **No plaintext API keys in localStorage**
+  - `packages/app/src/store/index.ts` persists only `encrypted` key material and forces `key: ''` during serialization.
+  - Added regression test: `packages/app/src/store/__tests__/index.test.ts`.
+
+- [x] **No key leakage in network request URLs/referrer paths**
+  - Fixed Google free-client validation/model-list calls to use `x-goog-api-key` headers instead of `?key=...` query params.
+  - Updated in `packages/shared-utils/src/providers/clients/google/FreeGoogleClient.ts`.
+  - Added/updated tests in:
+    - `packages/shared-utils/src/providers/clients/google/FreeGoogleClient.test.ts`
+    - `packages/shared-utils/src/providers/__tests__/free-clients.test.ts`
+
+- [x] **No key leakage in error/console output (provider/client paths)**
+  - Added shared redaction utility:
+    - `packages/shared-utils/src/providers/utils/sanitizeSensitiveData.ts`
+  - Wired redaction into:
+    - `packages/shared-utils/src/providers/utils/extractAxiosError.ts`
+    - `packages/shared-utils/src/providers/clients/base/BaseFreeClient.ts`
+    - `packages/shared-utils/src/providers/clients/openai/FreeOpenAIClient.ts`
+    - `packages/shared-utils/src/providers/clients/anthropic/FreeAnthropicClient.ts`
+    - `packages/shared-utils/src/providers/clients/google/FreeGoogleClient.ts`
+    - `packages/shared-utils/src/providers/clients/xai/FreeXAIClient.ts`
+    - `packages/shared-utils/src/providers/clients/deepseek/FreeDeepSeekClient.ts`
+    - `packages/shared-utils/src/providers/clients/perplexity/FreePerplexityClient.ts`
+    - `packages/app/src/lib/validation.ts`
+  - Added tests: `packages/shared-utils/src/providers/utils/sanitizeSensitiveData.test.ts`.
+
+- [x] **Pro mode server-side key exposure review**
+  - Current codebase does not implement server-side provider key storage flows for Pro mode yet.
+  - No server route currently returns provider API keys to the client.
+  - Current provider registration in app initializes `mock` and `free` only (`packages/app/src/providers/index.ts`).
+
+- [x] **tRPC protected route authorization review**
+  - Current router surface is public-only example routes (`packages/app/src/server/api/routers/post.ts`).
+  - No protected procedures/routes are currently implemented; therefore no protected-route auth bypass was identified in existing routes.
+  - Follow-up required when Pro-mode server APIs are added: define and enforce auth middleware for all non-public procedures.
+
+## Risk Notes
+
+- Free mode necessarily sends user-owned keys in outbound provider auth headers; this is expected for direct-from-browser architecture.
+- Before shipping Pro mode, add authenticated `protectedProcedure` middleware and explicit tests asserting unauthorized access is rejected.

--- a/packages/app/src/store/__tests__/index.test.ts
+++ b/packages/app/src/store/__tests__/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import type { StoreState } from '../index';
+import { serializeStoreState } from '../index';
+
+function createStateWithApiKey(): StoreState {
+  return {
+    apiKeys: {
+      openai: {
+        key: 'sk-secret-key',
+        encrypted: 'iv:ciphertext',
+        visible: true,
+        status: 'valid',
+      },
+      anthropic: null,
+      google: null,
+      xai: null,
+      deepseek: null,
+      perplexity: null,
+    },
+    encryptionInitialized: true,
+  } as unknown as StoreState;
+}
+
+describe('serializeStoreState', () => {
+  it('removes plaintext API keys while preserving encrypted payloads', () => {
+    const input = createStateWithApiKey();
+
+    const serialized = serializeStoreState(input);
+
+    expect(serialized.apiKeys.openai?.key).toBe('');
+    expect(serialized.apiKeys.openai?.encrypted).toBe('iv:ciphertext');
+    expect(serialized.apiKeys.openai?.visible).toBe(false);
+    expect(serialized.encryptionInitialized).toBe(false);
+  });
+});

--- a/packages/shared-utils/src/providers/__tests__/free-clients.test.ts
+++ b/packages/shared-utils/src/providers/__tests__/free-clients.test.ts
@@ -187,8 +187,8 @@ describe('Free mode provider clients', () => {
       const result = await client.validateApiKey('AIza-test');
       expect(result.valid).toBe(true);
       expect(mocks.axiosGet).toHaveBeenCalledWith('https://generativelanguage.googleapis.com/v1beta/models', {
-        params: {
-          key: 'AIza-test',
+        headers: {
+          'x-goog-api-key': 'AIza-test',
         },
       });
     });

--- a/packages/shared-utils/src/providers/clients/deepseek/FreeDeepSeekClient.ts
+++ b/packages/shared-utils/src/providers/clients/deepseek/FreeDeepSeekClient.ts
@@ -1,6 +1,7 @@
 import OpenAI from 'openai';
 import { BaseFreeClient, type StreamOptions, type StructuredOptions } from '../base/BaseFreeClient';
 import type { StructuredResponse, ValidationResult } from '../../types';
+import { sanitizeProviderErrorMessage } from '../../utils/sanitizeSensitiveData';
 
 export class FreeDeepSeekClient extends BaseFreeClient {
   private createClient(apiKey: string) {
@@ -21,7 +22,13 @@ export class FreeDeepSeekClient extends BaseFreeClient {
       await client.models.list();
       return { valid: true };
     } catch (error) {
-      return { valid: false, error: error instanceof Error ? error.message : 'Invalid DeepSeek API key.' };
+      return {
+        valid: false,
+        error: sanitizeProviderErrorMessage(
+          error instanceof Error ? error.message : String(error),
+          'Invalid DeepSeek API key.',
+        ),
+      };
     }
   }
 
@@ -117,9 +124,10 @@ export class FreeDeepSeekClient extends BaseFreeClient {
 
       options.onComplete(fullResponse, Date.now() - startTime, tokenCount > 0 ? tokenCount : undefined);
     } catch (error) {
-      const errorMessage = error instanceof Error
-        ? error.message
-        : String(error);
+      const errorMessage = sanitizeProviderErrorMessage(
+        error instanceof Error ? error.message : String(error),
+        'Unknown DeepSeek provider error.',
+      );
       options.onError(new Error(`DeepSeek API error: ${errorMessage}`));
     }
   }

--- a/packages/shared-utils/src/providers/clients/google/FreeGoogleClient.test.ts
+++ b/packages/shared-utils/src/providers/clients/google/FreeGoogleClient.test.ts
@@ -34,8 +34,8 @@ describe('FreeGoogleClient', () => {
         expect(axios.get).toHaveBeenCalledWith(
             'https://generativelanguage.googleapis.com/v1beta/models',
             {
-                params: {
-                    key: mockApiKey,
+                headers: {
+                    'x-goog-api-key': mockApiKey,
                 },
             }
         );
@@ -72,5 +72,21 @@ describe('FreeGoogleClient', () => {
         // BaseFreeClient catches error and returns mock models
         expect(models.length).toBeGreaterThan(0);
         expect(models).toContain('Gemini 1.5 Pro'); // From mock list
+    });
+
+    it('should validate API keys via x-goog-api-key header', async () => {
+        vi.mocked(axios.get).mockResolvedValue({ data: { models: [] } });
+
+        const result = await client.validateApiKey(mockApiKey);
+
+        expect(result).toEqual({ valid: true });
+        expect(axios.get).toHaveBeenCalledWith(
+            'https://generativelanguage.googleapis.com/v1beta/models',
+            {
+                headers: {
+                    'x-goog-api-key': mockApiKey,
+                },
+            }
+        );
     });
 });

--- a/packages/shared-utils/src/providers/clients/openai/FreeOpenAIClient.ts
+++ b/packages/shared-utils/src/providers/clients/openai/FreeOpenAIClient.ts
@@ -2,6 +2,7 @@ import OpenAI from 'openai';
 import { BaseFreeClient, type StreamOptions, type StructuredOptions } from '../base/BaseFreeClient';
 import type { StructuredResponse, ValidationResult } from '../../types';
 import { hasNonTextModality } from '../../utils/modelFilters';
+import { sanitizeProviderErrorMessage } from '../../utils/sanitizeSensitiveData';
 
 export class FreeOpenAIClient extends BaseFreeClient {
   private createClient(apiKey: string) {
@@ -22,7 +23,13 @@ export class FreeOpenAIClient extends BaseFreeClient {
       await client.models.retrieve('gpt-4o-mini');
       return { valid: true };
     } catch (error) {
-      return { valid: false, error: error instanceof Error ? error.message : 'Invalid OpenAI API key.' };
+      return {
+        valid: false,
+        error: sanitizeProviderErrorMessage(
+          error instanceof Error ? error.message : String(error),
+          'Invalid OpenAI API key.',
+        ),
+      };
     }
   }
 

--- a/packages/shared-utils/src/providers/clients/xai/FreeXAIClient.ts
+++ b/packages/shared-utils/src/providers/clients/xai/FreeXAIClient.ts
@@ -4,6 +4,7 @@ import { BaseFreeClient, type StreamOptions, type StructuredOptions } from '../b
 import type { StructuredResponse, ValidationResult } from '../../types';
 import { extractAxiosErrorMessage } from '../../utils/extractAxiosError';
 import { hasNonTextModality } from '../../utils/modelFilters';
+import { sanitizeProviderErrorMessage } from '../../utils/sanitizeSensitiveData';
 
 interface XaiModelEntry {
   id?: string;
@@ -154,9 +155,10 @@ export class FreeXAIClient extends BaseFreeClient {
       options.onComplete(fullResponse, Date.now() - startTime, tokenCount > 0 ? tokenCount : undefined);
     } catch (error) {
       // Extract error message from XAI/OpenAI SDK error
-      const errorMessage = error instanceof Error
-        ? error.message
-        : String(error);
+      const errorMessage = sanitizeProviderErrorMessage(
+        error instanceof Error ? error.message : String(error),
+        'Unknown xAI provider error.',
+      );
       options.onError(new Error(`XAI API error: ${errorMessage}`));
     }
   }

--- a/packages/shared-utils/src/providers/index.ts
+++ b/packages/shared-utils/src/providers/index.ts
@@ -8,3 +8,4 @@ export * from './clients/google/FreeGoogleClient';
 export * from './clients/xai/FreeXAIClient';
 export * from './clients/deepseek/FreeDeepSeekClient';
 export * from './clients/perplexity/FreePerplexityClient';
+export * from './utils/sanitizeSensitiveData';

--- a/packages/shared-utils/src/providers/utils/extractAxiosError.ts
+++ b/packages/shared-utils/src/providers/utils/extractAxiosError.ts
@@ -1,17 +1,18 @@
 import axios from 'axios';
+import { sanitizeProviderErrorMessage } from './sanitizeSensitiveData';
 
 export function extractAxiosErrorMessage(error: unknown): string {
   if (axios.isAxiosError(error)) {
-    return (
+    return sanitizeProviderErrorMessage(
       error.response?.data?.error?.message ??
       error.response?.data?.message ??
       error.message ??
-      'Unknown provider error.'
+      'Unknown provider error.',
     );
   }
 
   if (error instanceof Error) {
-    return error.message;
+    return sanitizeProviderErrorMessage(error.message);
   }
 
   return 'Unknown provider error.';

--- a/packages/shared-utils/src/providers/utils/sanitizeSensitiveData.test.ts
+++ b/packages/shared-utils/src/providers/utils/sanitizeSensitiveData.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  redactSensitiveData,
+  sanitizeProviderErrorMessage,
+} from './sanitizeSensitiveData';
+
+describe('sanitizeSensitiveData', () => {
+  it('redacts key-like query params and bearer tokens', () => {
+    const message =
+      'Request failed: https://example.com/v1/models?key=AIzaSyAbCdEfGh1234567890 and Authorization: Bearer sk-test-1234567890';
+
+    const result = redactSensitiveData(message);
+
+    expect(result).toContain('?key=[REDACTED]');
+    expect(result).toContain('Bearer [REDACTED]');
+    expect(result).not.toContain('AIzaSyAbCdEfGh1234567890');
+    expect(result).not.toContain('sk-test-1234567890');
+  });
+
+  it('redacts known provider API key shapes in plain text', () => {
+    const result = redactSensitiveData(
+      'Invalid key sk-ant-abcdefghijklmnop and pplx-1234567890',
+    );
+
+    expect(result).toBe('Invalid key [REDACTED] and [REDACTED]');
+  });
+
+  it('uses fallback for empty messages', () => {
+    expect(sanitizeProviderErrorMessage('', 'fallback')).toBe('fallback');
+  });
+});

--- a/packages/shared-utils/src/providers/utils/sanitizeSensitiveData.ts
+++ b/packages/shared-utils/src/providers/utils/sanitizeSensitiveData.ts
@@ -1,0 +1,38 @@
+const URL_KEY_PARAM_PATTERN = /([?&](?:key|api[_-]?key|apikey)=)([^&#\s]+)/gi;
+const BEARER_TOKEN_PATTERN = /\b(Bearer\s+)([A-Za-z0-9._-]{8,})\b/g;
+const AUTH_HEADER_PATTERN = /(\bAuthorization\s*[:=]\s*Bearer\s+)([A-Za-z0-9._-]{8,})\b/gi;
+const KNOWN_API_KEY_PATTERNS: RegExp[] = [
+  /\bsk-(?:proj-)?[A-Za-z0-9_-]{8,}\b/g,
+  /\bsk-ant-[A-Za-z0-9_-]{8,}\b/g,
+  /\bAIza[0-9A-Za-z_-]{20,}\b/g,
+  /\bxai-[A-Za-z0-9_-]{8,}\b/g,
+  /\bpplx-[A-Za-z0-9_-]{8,}\b/g,
+];
+
+const REDACTED_VALUE = '[REDACTED]';
+
+function redactKnownApiKeyShapes(input: string): string {
+  return KNOWN_API_KEY_PATTERNS.reduce(
+    (result, pattern) => result.replace(pattern, REDACTED_VALUE),
+    input,
+  );
+}
+
+export function redactSensitiveData(input: string): string {
+  return redactKnownApiKeyShapes(input)
+    .replace(URL_KEY_PARAM_PATTERN, `$1${REDACTED_VALUE}`)
+    .replace(BEARER_TOKEN_PATTERN, `$1${REDACTED_VALUE}`)
+    .replace(AUTH_HEADER_PATTERN, `$1${REDACTED_VALUE}`);
+}
+
+export function sanitizeProviderErrorMessage(
+  message: string | null | undefined,
+  fallback = 'Unknown provider error.',
+): string {
+  if (!message) {
+    return fallback;
+  }
+
+  const redacted = redactSensitiveData(message).trim();
+  return redacted.length > 0 ? redacted : fallback;
+}


### PR DESCRIPTION
## Summary
- add a formal security audit report for issue #56 (`docs/security-audit-issue-56.md`)
- remove Google Free mode API key leakage risk by switching from URL query params to `x-goog-api-key` headers
- add shared sensitive-data redaction and apply it across provider/client error paths
- sanitize app-side API key validation error handling to avoid propagating raw key-like material
- add regression tests for redaction and persisted-store plaintext key stripping

## Validation
- `cd packages/shared-utils && npx vitest run src/providers/utils/sanitizeSensitiveData.test.ts src/providers/clients/google/FreeGoogleClient.test.ts src/providers/__tests__/free-clients.test.ts`
- `cd packages/app && npx vitest run src/store/__tests__/index.test.ts src/store/__tests__/apiKeySlice.test.ts`
- `npm run lint --workspace=packages/shared-utils`
- `npm run typecheck --workspace=packages/shared-utils`
- `npm run lint --workspace=packages/app`
- `npm run typecheck --workspace=packages/app`
- `cd packages/e2e && E2E_MODE=free npx playwright test tests/free-mode/free-mode.spec.ts --project=free-mode --workers=1`
- `cd packages/e2e && E2E_MODE=free npx playwright test tests/free-mode/google-only.spec.ts --project=free-mode --workers=1`

Fixes #56