### PR TITLE
feat: ConsensusMetrics molecule component

### DIFF
--- a/packages/component-library/src/components/molecules/ConsensusMetrics/ConsensusMetrics.stories.tsx
+++ b/packages/component-library/src/components/molecules/ConsensusMetrics/ConsensusMetrics.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ConsensusMetrics } from "./ConsensusMetrics";
+
+const meta = {
+  title: "Molecules/ConsensusMetrics",
+  component: ConsensusMetrics,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    roundsToConsensus: {
+      control: { type: "number", min: 0, max: 20 },
+      description: "Number of rounds needed to reach consensus",
+    },
+    finalAgreement: {
+      control: { type: "range", min: 0, max: 100, step: 1 },
+      description: "Final agreement percentage (0-100)",
+    },
+    unanimousConsensus: {
+      control: "boolean",
+      description: "Whether consensus was unanimous",
+    },
+    maxRounds: {
+      control: { type: "number", min: 1, max: 20 },
+      description: "Maximum number of council rounds",
+    },
+  },
+} satisfies Meta<typeof ConsensusMetrics>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    roundsToConsensus: 3,
+    finalAgreement: 78,
+    unanimousConsensus: false,
+    maxRounds: 5,
+  },
+};
+
+export const HighAgreementUnanimous: Story = {
+  args: {
+    roundsToConsensus: 2,
+    finalAgreement: 94,
+    unanimousConsensus: true,
+    maxRounds: 5,
+  },
+};
+
+export const LowAgreementSplit: Story = {
+  args: {
+    roundsToConsensus: 5,
+    finalAgreement: 33,
+    unanimousConsensus: false,
+    maxRounds: 5,
+  },
+};

--- a/packages/component-library/src/components/molecules/ConsensusMetrics/ConsensusMetrics.test.tsx
+++ b/packages/component-library/src/components/molecules/ConsensusMetrics/ConsensusMetrics.test.tsx
@@ -1,0 +1,119 @@
+import * as React from "react";
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithI18n } from "../../../lib/test-utils/i18n-test-wrapper";
+import { ConsensusMetrics } from "./ConsensusMetrics";
+
+describe("ConsensusMetrics", () => {
+  const defaultProps = {
+    roundsToConsensus: 3,
+    finalAgreement: 78,
+    unanimousConsensus: false,
+    maxRounds: 5,
+  };
+
+  it("renders the component and stat labels", () => {
+    renderWithI18n(<ConsensusMetrics {...defaultProps} />);
+
+    expect(screen.getByTestId("consensus-metrics")).toBeInTheDocument();
+    expect(screen.getByText("Rounds")).toBeInTheDocument();
+    expect(screen.getByText("Final Agreement")).toBeInTheDocument();
+    expect(screen.getByText("Unanimous")).toBeInTheDocument();
+  });
+
+  it("renders rounds text and progress indicator values", () => {
+    renderWithI18n(<ConsensusMetrics {...defaultProps} />);
+
+    expect(screen.getByText("3/5 rounds")).toBeInTheDocument();
+    const progress = screen.getByTestId("consensus-metrics-rounds-progress");
+    expect(progress).toHaveAttribute("aria-valuenow", "3");
+    expect(progress).toHaveAttribute("aria-valuemax", "5");
+  });
+
+  it("renders agreement percentage and medium level", () => {
+    renderWithI18n(<ConsensusMetrics {...defaultProps} finalAgreement={65} />);
+
+    expect(screen.getByText("65%")).toBeInTheDocument();
+    const agreement = screen.getByTestId("consensus-metrics-agreement");
+    expect(agreement).toHaveAttribute("data-agreement-level", "medium");
+  });
+
+  it("renders high and low agreement levels", () => {
+    const { rerender } = renderWithI18n(
+      <ConsensusMetrics {...defaultProps} finalAgreement={91} />,
+    );
+
+    expect(screen.getByTestId("consensus-metrics-agreement")).toHaveAttribute(
+      "data-agreement-level",
+      "high",
+    );
+
+    rerender(<ConsensusMetrics {...defaultProps} finalAgreement={22} />);
+
+    expect(screen.getByTestId("consensus-metrics-agreement")).toHaveAttribute(
+      "data-agreement-level",
+      "low",
+    );
+  });
+
+  it("sets progress variant for warning and destructive round counts", () => {
+    const { rerender } = renderWithI18n(
+      <ConsensusMetrics
+        {...defaultProps}
+        roundsToConsensus={4}
+        maxRounds={5}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("consensus-metrics-rounds-progress"),
+    ).toHaveAttribute("data-variant", "warning");
+
+    rerender(
+      <ConsensusMetrics
+        {...defaultProps}
+        roundsToConsensus={5}
+        maxRounds={5}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("consensus-metrics-rounds-progress"),
+    ).toHaveAttribute("data-variant", "destructive");
+  });
+
+  it("renders unanimous true and false states", () => {
+    const { rerender } = renderWithI18n(
+      <ConsensusMetrics {...defaultProps} unanimousConsensus />,
+    );
+
+    expect(screen.getByText("Yes")).toBeInTheDocument();
+
+    rerender(<ConsensusMetrics {...defaultProps} unanimousConsensus={false} />);
+
+    expect(screen.getByText("No")).toBeInTheDocument();
+  });
+
+  it("forwards ref and merges className", () => {
+    const ref = React.createRef<HTMLDivElement>();
+
+    renderWithI18n(
+      <ConsensusMetrics {...defaultProps} className="custom-class" ref={ref} />,
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    expect(ref.current).toHaveClass("custom-class");
+  });
+
+  it("renders French translations", () => {
+    renderWithI18n(<ConsensusMetrics {...defaultProps} unanimousConsensus />, {
+      language: "fr",
+    });
+
+    expect(screen.getByText("Tours")).toBeInTheDocument();
+    expect(screen.getByText("Accord final")).toBeInTheDocument();
+    expect(screen.getByText("Unanime")).toBeInTheDocument();
+    expect(screen.getByText("Oui")).toBeInTheDocument();
+    expect(screen.getByText("3/5 tours")).toBeInTheDocument();
+  });
+});

--- a/packages/component-library/src/components/molecules/ConsensusMetrics/ConsensusMetrics.tsx
+++ b/packages/component-library/src/components/molecules/ConsensusMetrics/ConsensusMetrics.tsx
@@ -1,0 +1,153 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { CheckCircle2, XCircle } from "lucide-react";
+import { Progress } from "../../atoms/Progress";
+import { Text } from "../../atoms/Text";
+import { cn } from "../../../lib/utils";
+
+export interface ConsensusMetricsProps {
+  /** Number of rounds needed to reach consensus */
+  roundsToConsensus: number;
+  /** Final agreement percentage (0-100) */
+  finalAgreement: number;
+  /** Whether consensus was unanimous */
+  unanimousConsensus: boolean;
+  /** Maximum number of council rounds */
+  maxRounds: number;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * ConsensusMetrics molecule for displaying council consensus outcomes.
+ *
+ * Shows rounds-to-consensus progress, final agreement level, and whether
+ * consensus was unanimous.
+ *
+ * @example
+ * ```tsx
+ * <ConsensusMetrics
+ *   roundsToConsensus={3}
+ *   finalAgreement={82}
+ *   unanimousConsensus={false}
+ *   maxRounds={5}
+ * />
+ * ```
+ */
+export const ConsensusMetrics = React.forwardRef<
+  HTMLDivElement,
+  ConsensusMetricsProps
+>(
+  (
+    {
+      roundsToConsensus,
+      finalAgreement,
+      unanimousConsensus,
+      maxRounds,
+      className,
+    },
+    ref,
+  ) => {
+    const { t } = useTranslation();
+
+    const safeMaxRounds = Math.max(1, Math.floor(maxRounds));
+    const safeRounds = Math.min(
+      Math.max(Math.floor(roundsToConsensus), 0),
+      safeMaxRounds,
+    );
+    const safeAgreement = Math.min(
+      Math.max(Math.round(finalAgreement), 0),
+      100,
+    );
+
+    const agreementLevel =
+      safeAgreement >= 80
+        ? { key: "high", color: "text-success" }
+        : safeAgreement >= 50
+          ? { key: "medium", color: "text-warning" }
+          : { key: "low", color: "text-destructive" };
+
+    const roundsVariant =
+      safeRounds <= Math.ceil(safeMaxRounds / 2)
+        ? "success"
+        : safeRounds < safeMaxRounds
+          ? "warning"
+          : "destructive";
+
+    return (
+      <div
+        ref={ref}
+        data-testid="consensus-metrics"
+        className={cn("grid grid-cols-1 gap-4 sm:grid-cols-3", className)}
+      >
+        <div className="border-border bg-card rounded-lg border p-4">
+          <Text variant="small" color="muted">
+            {t("molecules.consensusMetrics.roundsLabel")}
+          </Text>
+          <Text className="text-foreground mt-1 text-xl font-semibold">
+            {t("molecules.consensusMetrics.roundsValue", {
+              rounds: safeRounds,
+              maxRounds: safeMaxRounds,
+            })}
+          </Text>
+          <Progress
+            value={safeRounds}
+            max={safeMaxRounds}
+            variant={roundsVariant}
+            className="mt-3"
+            data-testid="consensus-metrics-rounds-progress"
+          />
+        </div>
+
+        <div className="border-border bg-card rounded-lg border p-4">
+          <Text variant="small" color="muted">
+            {t("molecules.consensusMetrics.finalAgreementLabel")}
+          </Text>
+          <div
+            className={cn("mt-1 text-xl font-semibold", agreementLevel.color)}
+            data-testid="consensus-metrics-agreement"
+            data-agreement-level={agreementLevel.key}
+          >
+            {safeAgreement}%
+          </div>
+          <Text variant="small" className={cn("mt-3", agreementLevel.color)}>
+            {t(`molecules.consensusMetrics.agreement.${agreementLevel.key}`)}
+          </Text>
+        </div>
+
+        <div className="border-border bg-card rounded-lg border p-4">
+          <Text variant="small" color="muted">
+            {t("molecules.consensusMetrics.unanimousLabel")}
+          </Text>
+          <div
+            className={cn(
+              "mt-2 flex items-center gap-2 text-xl font-semibold",
+              unanimousConsensus ? "text-success" : "text-destructive",
+            )}
+            data-testid="consensus-metrics-unanimous"
+            data-unanimous={unanimousConsensus ? "true" : "false"}
+          >
+            {unanimousConsensus ? (
+              <CheckCircle2
+                className="h-5 w-5"
+                aria-label={t("molecules.consensusMetrics.unanimousYes")}
+              />
+            ) : (
+              <XCircle
+                className="h-5 w-5"
+                aria-label={t("molecules.consensusMetrics.unanimousNo")}
+              />
+            )}
+            <span>
+              {unanimousConsensus
+                ? t("molecules.consensusMetrics.unanimousYes")
+                : t("molecules.consensusMetrics.unanimousNo")}
+            </span>
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+
+ConsensusMetrics.displayName = "ConsensusMetrics";

--- a/packages/component-library/src/components/molecules/ConsensusMetrics/index.ts
+++ b/packages/component-library/src/components/molecules/ConsensusMetrics/index.ts
@@ -1,0 +1,1 @@
+export { ConsensusMetrics, type ConsensusMetricsProps } from './ConsensusMetrics';

--- a/packages/component-library/src/index.ts
+++ b/packages/component-library/src/index.ts
@@ -86,6 +86,7 @@ export {
   type ProgressStepsProps,
 } from './components/molecules/ProgressSteps';
 export { SummarizerIndicator, type SummarizerIndicatorProps } from './components/molecules/SummarizerIndicator';
+export { ConsensusMetrics, type ConsensusMetricsProps } from './components/molecules/ConsensusMetrics';
 
 // Organisms (Level 3: Complex UI sections)
 export { ModeSelector, type ModeSelectorProps, type Mode as ModeType } from './components/organisms/ModeSelector';

--- a/packages/component-library/src/lib/i18n/locales/en.json
+++ b/packages/component-library/src/lib/i18n/locales/en.json
@@ -74,6 +74,19 @@
     },
     "summarizerIndicator": {
       "label": "Summarizer Model:"
+    },
+    "consensusMetrics": {
+      "roundsLabel": "Rounds",
+      "roundsValue": "{{rounds}}/{{maxRounds}} rounds",
+      "finalAgreementLabel": "Final Agreement",
+      "unanimousLabel": "Unanimous",
+      "unanimousYes": "Yes",
+      "unanimousNo": "No",
+      "agreement": {
+        "high": "High agreement",
+        "medium": "Medium agreement",
+        "low": "Low agreement"
+      }
     }
   },
   "organisms": {

--- a/packages/component-library/src/lib/i18n/locales/fr.json
+++ b/packages/component-library/src/lib/i18n/locales/fr.json
@@ -74,6 +74,19 @@
     },
     "summarizerIndicator": {
       "label": "Modèle de synthèse :"
+    },
+    "consensusMetrics": {
+      "roundsLabel": "Tours",
+      "roundsValue": "{{rounds}}/{{maxRounds}} tours",
+      "finalAgreementLabel": "Accord final",
+      "unanimousLabel": "Unanime",
+      "unanimousYes": "Oui",
+      "unanimousNo": "Non",
+      "agreement": {
+        "high": "Accord élevé",
+        "medium": "Accord moyen",
+        "low": "Accord faible"
+      }
     }
   },
   "organisms": {


### PR DESCRIPTION
## Summary
- implement `ConsensusMetrics` molecule at `packages/component-library/src/components/molecules/ConsensusMetrics/`
- add Storybook stories and unit tests with EN/FR i18n assertions
- export the new molecule from `packages/component-library/src/index.ts`
- add EN/FR locale keys under `molecules.consensusMetrics`

## Validation
- `cd packages/component-library && npx vitest run src/components/molecules/ConsensusMetrics/ConsensusMetrics.test.tsx --coverage.enabled=false`
- pre-commit hooks passed: component-library lint + full unit tests/coverage, app lint + typecheck, FTA analysis

Closes #199
