### PR TITLE
feat: FinalVotesSummary molecule component

### DIFF
--- a/packages/component-library/src/components/molecules/FinalVotesSummary/FinalVotesSummary.stories.tsx
+++ b/packages/component-library/src/components/molecules/FinalVotesSummary/FinalVotesSummary.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { FinalVotesSummary } from "./FinalVotesSummary";
+
+const meta = {
+  title: "Molecules/FinalVotesSummary",
+  component: FinalVotesSummary,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof FinalVotesSummary>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const responses = [
+  { modelId: "gpt4", modelName: "GPT-4", provider: "openai" },
+  { modelId: "claude", modelName: "Claude 3 Opus", provider: "anthropic" },
+  { modelId: "gemini", modelName: "Gemini Pro", provider: "google" },
+];
+
+export const Default: Story = {
+  args: {
+    votes: [
+      {
+        modelId: "gpt4",
+        decision: "Adopt option A",
+        reasoning: "Option A balances risk and speed.",
+        confidence: 92,
+      },
+      {
+        modelId: "claude",
+        decision: "Adopt option B",
+        reasoning: "Option B has better long-term maintainability.",
+        confidence: 67,
+      },
+      {
+        modelId: "gemini",
+        decision: "Defer decision",
+        reasoning: "Need more evidence before selecting an option.",
+        confidence: 31,
+      },
+    ],
+    responses,
+  },
+};
+
+export const EmptyVotes: Story = {
+  args: {
+    votes: [],
+    responses,
+  },
+};

--- a/packages/component-library/src/components/molecules/FinalVotesSummary/FinalVotesSummary.test.tsx
+++ b/packages/component-library/src/components/molecules/FinalVotesSummary/FinalVotesSummary.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithI18n } from "../../../lib/test-utils/i18n-test-wrapper";
+import { FinalVotesSummary } from "./FinalVotesSummary";
+
+const votes = [
+  {
+    modelId: "gpt4",
+    decision: "Adopt option A",
+    reasoning: "Option A balances risk and speed.",
+    confidence: 92,
+  },
+  {
+    modelId: "claude",
+    decision: "Adopt option B",
+    reasoning: "Option B has better long-term maintainability.",
+    confidence: 67,
+  },
+  {
+    modelId: "gemini",
+    decision: "Defer decision",
+    reasoning: "Need more evidence before selecting an option.",
+    confidence: 31,
+  },
+];
+
+const responses = [
+  { modelId: "gpt4", modelName: "GPT-4", provider: "openai" },
+  { modelId: "claude", modelName: "Claude 3 Opus", provider: "anthropic" },
+  { modelId: "gemini", modelName: "Gemini Pro", provider: "google" },
+];
+
+describe("FinalVotesSummary", () => {
+  it("renders all votes with model metadata", () => {
+    renderWithI18n(<FinalVotesSummary votes={votes} responses={responses} />);
+
+    expect(screen.getByTestId("final-votes-summary")).toBeInTheDocument();
+    expect(screen.getByText("GPT-4")).toBeInTheDocument();
+    expect(screen.getByText("Claude 3 Opus")).toBeInTheDocument();
+    expect(screen.getByText("Gemini Pro")).toBeInTheDocument();
+    expect(screen.getByText("Adopt option A")).toBeInTheDocument();
+    expect(screen.getByText("Adopt option B")).toBeInTheDocument();
+    expect(screen.getByText("Defer decision")).toBeInTheDocument();
+  });
+
+  it("renders confidence percentages and color variants", () => {
+    renderWithI18n(<FinalVotesSummary votes={votes} responses={responses} />);
+
+    expect(screen.getByText("92%")).toBeInTheDocument();
+    expect(screen.getByText("67%")).toBeInTheDocument();
+    expect(screen.getByText("31%")).toBeInTheDocument();
+
+    expect(screen.getByTestId("final-vote-confidence-gpt4")).toHaveAttribute(
+      "data-variant",
+      "success",
+    );
+    expect(screen.getByTestId("final-vote-confidence-claude")).toHaveAttribute(
+      "data-variant",
+      "warning",
+    );
+    expect(screen.getByTestId("final-vote-confidence-gemini")).toHaveAttribute(
+      "data-variant",
+      "destructive",
+    );
+  });
+
+  it("expands and collapses reasoning", async () => {
+    const user = userEvent.setup();
+
+    renderWithI18n(<FinalVotesSummary votes={votes} responses={responses} />);
+
+    expect(
+      screen.queryByText("Option A balances risk and speed."),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("final-vote-toggle-gpt4"));
+
+    expect(
+      screen.getByText("Option A balances risk and speed."),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("final-vote-toggle-gpt4"));
+
+    expect(
+      screen.queryByText("Option A balances risk and speed."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders fallback metadata for unknown model response", () => {
+    renderWithI18n(
+      <FinalVotesSummary
+        votes={[
+          {
+            modelId: "unknown-model",
+            decision: "Unknown decision",
+            reasoning: "Unknown reasoning",
+            confidence: 50,
+          },
+        ]}
+        responses={[]}
+      />,
+    );
+
+    expect(screen.getByText("unknown-model")).toBeInTheDocument();
+    expect(screen.getByText("Unknown provider")).toBeInTheDocument();
+  });
+
+  it("renders no-votes state", () => {
+    renderWithI18n(<FinalVotesSummary votes={[]} responses={responses} />);
+
+    expect(screen.getByText("No final votes available")).toBeInTheDocument();
+  });
+
+  it("renders French translations", async () => {
+    const user = userEvent.setup();
+
+    renderWithI18n(<FinalVotesSummary votes={votes} responses={responses} />, {
+      language: "fr",
+    });
+
+    expect(screen.getAllByText("Confiance").length).toBeGreaterThan(0);
+
+    const toggle = screen.getByTestId("final-vote-toggle-gpt4");
+    expect(toggle).toHaveTextContent("Afficher le raisonnement");
+
+    await user.click(toggle);
+
+    expect(toggle).toHaveTextContent("Masquer le raisonnement");
+    expect(
+      screen.getByText("Option A balances risk and speed."),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/component-library/src/components/molecules/FinalVotesSummary/FinalVotesSummary.tsx
+++ b/packages/component-library/src/components/molecules/FinalVotesSummary/FinalVotesSummary.tsx
@@ -1,0 +1,188 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { Badge } from "../../atoms/Badge";
+import { Button } from "../../atoms/Button";
+import { Progress } from "../../atoms/Progress";
+import { Text } from "../../atoms/Text";
+import { cn } from "../../../lib/utils";
+
+interface FinalVote {
+  modelId: string;
+  decision: string;
+  reasoning: string;
+  confidence: number;
+}
+
+interface VoteResponseReference {
+  modelId: string;
+  modelName: string;
+  provider: string;
+}
+
+export interface FinalVotesSummaryProps {
+  /** Final votes cast by each council member */
+  votes: FinalVote[];
+  /** Response metadata used to resolve model/provider display names */
+  responses: VoteResponseReference[];
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * FinalVotesSummary molecule for displaying per-model council votes.
+ *
+ * Renders each model's final decision, confidence bar, and expandable
+ * reasoning content.
+ */
+export const FinalVotesSummary = React.forwardRef<
+  HTMLDivElement,
+  FinalVotesSummaryProps
+>(({ votes, responses, className }, ref) => {
+  const { t } = useTranslation();
+  const [expandedVoteIds, setExpandedVoteIds] = React.useState<Set<string>>(
+    new Set(),
+  );
+
+  const responseMap = React.useMemo(
+    () => new Map(responses.map((response) => [response.modelId, response])),
+    [responses],
+  );
+
+  const toggleReasoning = (modelId: string) => {
+    setExpandedVoteIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(modelId)) {
+        next.delete(modelId);
+      } else {
+        next.add(modelId);
+      }
+      return next;
+    });
+  };
+
+  const getConfidenceVariant = (confidence: number) => {
+    if (confidence >= 80) {
+      return { variant: "success", color: "text-success" } as const;
+    }
+    if (confidence >= 50) {
+      return { variant: "warning", color: "text-warning" } as const;
+    }
+    return { variant: "destructive", color: "text-destructive" } as const;
+  };
+
+  if (votes.length === 0) {
+    return (
+      <div
+        ref={ref}
+        data-testid="final-votes-summary"
+        className={cn(
+          "border-border bg-card text-muted-foreground rounded-lg border p-4 text-sm",
+          className,
+        )}
+      >
+        {t("molecules.finalVotesSummary.noVotes")}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={ref}
+      data-testid="final-votes-summary"
+      className={cn("space-y-3", className)}
+    >
+      {votes.map((vote, index) => {
+        const metadata = responseMap.get(vote.modelId);
+        const modelName = metadata?.modelName ?? vote.modelId;
+        const providerName =
+          metadata?.provider != null
+            ? t(`providers.${metadata.provider}`, {
+                defaultValue: metadata.provider,
+              })
+            : t("molecules.finalVotesSummary.unknownProvider");
+
+        const safeConfidence = Math.min(
+          Math.max(Math.round(vote.confidence), 0),
+          100,
+        );
+        const confidenceStyle = getConfidenceVariant(safeConfidence);
+        const isExpanded = expandedVoteIds.has(vote.modelId);
+
+        return (
+          <div
+            key={`${vote.modelId}-${index}`}
+            data-testid={`final-vote-item-${vote.modelId}`}
+            className="border-border bg-card rounded-lg border p-4"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="outline">{modelName}</Badge>
+                <Text variant="caption" color="muted">
+                  {providerName}
+                </Text>
+              </div>
+
+              <div className="text-right">
+                <Text variant="caption" color="muted">
+                  {t("molecules.finalVotesSummary.confidenceLabel")}
+                </Text>
+                <div
+                  className={cn("text-sm font-semibold", confidenceStyle.color)}
+                >
+                  {safeConfidence}%
+                </div>
+              </div>
+            </div>
+
+            <Text
+              className="text-foreground mt-3 text-sm font-semibold"
+              data-testid={`final-vote-decision-${vote.modelId}`}
+            >
+              {vote.decision}
+            </Text>
+
+            <Progress
+              value={safeConfidence}
+              max={100}
+              variant={confidenceStyle.variant}
+              className="mt-2"
+              data-testid={`final-vote-confidence-${vote.modelId}`}
+            />
+
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="mt-2 h-auto px-0 py-0 text-sm"
+              onClick={() => toggleReasoning(vote.modelId)}
+              aria-expanded={isExpanded}
+              data-testid={`final-vote-toggle-${vote.modelId}`}
+            >
+              {isExpanded ? (
+                <ChevronUp className="mr-1 h-4 w-4" aria-hidden="true" />
+              ) : (
+                <ChevronDown className="mr-1 h-4 w-4" aria-hidden="true" />
+              )}
+              {isExpanded
+                ? t("molecules.finalVotesSummary.hideReasoning")
+                : t("molecules.finalVotesSummary.showReasoning")}
+            </Button>
+
+            {isExpanded ? (
+              <Text
+                variant="small"
+                className="text-muted-foreground mt-2"
+                data-testid={`final-vote-reasoning-${vote.modelId}`}
+              >
+                {vote.reasoning}
+              </Text>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+});
+
+FinalVotesSummary.displayName = "FinalVotesSummary";

--- a/packages/component-library/src/components/molecules/FinalVotesSummary/index.ts
+++ b/packages/component-library/src/components/molecules/FinalVotesSummary/index.ts
@@ -1,0 +1,4 @@
+export {
+  FinalVotesSummary,
+  type FinalVotesSummaryProps,
+} from "./FinalVotesSummary";

--- a/packages/component-library/src/index.ts
+++ b/packages/component-library/src/index.ts
@@ -86,6 +86,7 @@ export {
   type ProgressStepsProps,
 } from './components/molecules/ProgressSteps';
 export { SummarizerIndicator, type SummarizerIndicatorProps } from './components/molecules/SummarizerIndicator';
+export { FinalVotesSummary, type FinalVotesSummaryProps } from './components/molecules/FinalVotesSummary';
 
 // Organisms (Level 3: Complex UI sections)
 export { ModeSelector, type ModeSelectorProps, type Mode as ModeType } from './components/organisms/ModeSelector';

--- a/packages/component-library/src/lib/i18n/locales/en.json
+++ b/packages/component-library/src/lib/i18n/locales/en.json
@@ -74,6 +74,13 @@
     },
     "summarizerIndicator": {
       "label": "Summarizer Model:"
+    },
+    "finalVotesSummary": {
+      "confidenceLabel": "Confidence",
+      "showReasoning": "Show reasoning",
+      "hideReasoning": "Hide reasoning",
+      "noVotes": "No final votes available",
+      "unknownProvider": "Unknown provider"
     }
   },
   "organisms": {

--- a/packages/component-library/src/lib/i18n/locales/fr.json
+++ b/packages/component-library/src/lib/i18n/locales/fr.json
@@ -74,6 +74,13 @@
     },
     "summarizerIndicator": {
       "label": "Modèle de synthèse :"
+    },
+    "finalVotesSummary": {
+      "confidenceLabel": "Confiance",
+      "showReasoning": "Afficher le raisonnement",
+      "hideReasoning": "Masquer le raisonnement",
+      "noVotes": "Aucun vote final disponible",
+      "unknownProvider": "Fournisseur inconnu"
     }
   },
   "organisms": {


### PR DESCRIPTION
## Summary
- implement `FinalVotesSummary` molecule at `packages/component-library/src/components/molecules/FinalVotesSummary/`
- add Storybook stories and unit tests for rendering, confidence variants, reasoning expand/collapse, fallback metadata, and EN/FR i18n
- export the new molecule from `packages/component-library/src/index.ts`
- add EN/FR locale keys under `molecules.finalVotesSummary`

## Validation
- `cd packages/component-library && npx vitest run src/components/molecules/FinalVotesSummary/FinalVotesSummary.test.tsx --coverage.enabled=false`
- pre-commit hooks passed: component-library lint + full unit tests/coverage, app lint + typecheck, FTA analysis

Closes #198
